### PR TITLE
T251265: Fix icon centering

### DIFF
--- a/style/link.css
+++ b/style/link.css
@@ -9,6 +9,7 @@
 
 .wmf-wp-with-preview::after {
   content: inline-svg('../images/info_24_px.svg');
-  vertical-align: top;
+  display: inline-block;
+  vertical-align: middle;
   margin-left: 1px;
 }


### PR DESCRIPTION
Phab ticket: https://phabricator.wikimedia.org/T251265

This is a small follow up to #5 in order to [correctly centered](https://phabricator.wikimedia.org/T251265#6264751) the icon in the link CSS in Safari, this change works well with Firefox and Chrome also. 

Before | After 
--- | ---
<img width="153" alt="image" src="https://user-images.githubusercontent.com/4752599/86035968-26685600-ba0b-11ea-90fb-3ac7e33e2bcf.png"> | <img width="200" alt="image" src="https://user-images.githubusercontent.com/4752599/86036022-36803580-ba0b-11ea-9b9a-a4fac801269e.png">


---

https://stackoverflow.com/questions/17312521/vertical-align-is-not-working-in-safari-and-chrome




