### PR TITLE
add line-height to discovery link

### DIFF
--- a/style/link.css
+++ b/style/link.css
@@ -5,6 +5,7 @@
   border-radius: 4px;
   border: solid 1px rgba(51, 102, 204, 0.48);
   cursor: pointer;
+  line-height: normal;
 }
 
 .wmf-wp-with-preview::after {


### PR DESCRIPTION
when working on demo site, I found the content with `line-height` has the styling issue, therefore adding it to match the content line-height

| Before | 
| --- | 
| <img width="658" alt="before-lineheight" src="https://user-images.githubusercontent.com/2560096/87725928-72165000-c7be-11ea-8814-5566d30ddbc5.png"> |

| After |
| --- |
| <img width="769" alt="after-lineheight" src="https://user-images.githubusercontent.com/2560096/87725925-717db980-c7be-11ea-91b1-68e2f4c89194.png"> |

