### PR TITLE
stack timeout listener

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -2,7 +2,7 @@ import { isTouch } from './utils'
 
 export const customEvents = popup => {
 
-	var eventListenerStack = [],
+	let eventListenerStack = [],
 		timeoutStack = []
 	const addTimeout = ( func, timeout ) => {
 			const id = setTimeout( func, timeout )

--- a/src/event.js
+++ b/src/event.js
@@ -19,7 +19,7 @@ export const customEvents = popup => {
 			target.addEventListener( type, listener, options )
 			eventListenerStack.push( [ target, type, listener, options ] )
 		},
-		clearEventListener = () => {
+		clearAllEventListener = () => {
 			eventListenerStack.forEach( eventListener => {
 				const [ target, type, listener, options ] = eventListener
 				target.removeEventListener( type, listener, options )
@@ -53,7 +53,7 @@ export const customEvents = popup => {
 		},
 
 		onHide = () => {
-			clearEventListener()
+			clearAllEventListener()
 			clearAllTimeout()
 		},
 

--- a/src/event.js
+++ b/src/event.js
@@ -1,27 +1,43 @@
 import { isTouch } from './utils'
 
 export const customEvents = popup => {
-	const onMouseLeave = e => {
+
+	var eventListenerStack = [],
+		timeoutStack = []
+	const addTimeout = ( func, timeout ) => {
+			const id = setTimeout( func, timeout )
+			timeoutStack.push( id )
+			return id
+		},
+		clearAllTimeout = () => {
+			timeoutStack.forEach( timeoutId => {
+				clearTimeout( timeoutId )
+			} )
+			timeoutStack = []
+		},
+		addEventListener = ( target, type, listener, options = undefined ) => {
+			target.addEventListener( type, listener, options )
+			eventListenerStack.push( [ target, type, listener, options ] )
+		},
+		clearEventListener = () => {
+			eventListenerStack.forEach( eventListener => {
+				const [ target, type, listener, options ] = eventListener
+				target.removeEventListener( type, listener, options )
+			} )
+			eventListenerStack = []
+		},
+		onMouseLeave = e => {
 			const toElement = e.toElement || e.relatedTarget || e.target,
 				previewElement = popup.element.currentTargetElement
 
 			if ( toElement !== previewElement && !popup.element.contains( toElement ) ) {
 				let timeoutId
 				const persistPopup = () => {
-						popup.element.removeEventListener( 'mouseenter', persistPopup )
-						popup.timeoutId = null
-						clearTimeout( timeoutId )
-					},
+					clearTimeout( timeoutId )
+				}
 
-					hidePopup = () => {
-						popup.element.removeEventListener( 'mouseenter', persistPopup )
-						popup.timeoutId = null
-						popup.hide()
-					}
-
-				timeoutId = setTimeout( hidePopup, 300 )
-				popup.element.addEventListener( 'mouseenter', persistPopup )
-				popup.timeoutId = timeoutId
+				timeoutId = addTimeout( popup.hide, 300 )
+				addEventListener( popup.element, 'mouseenter', persistPopup )
 			}
 		},
 
@@ -36,16 +52,18 @@ export const customEvents = popup => {
 			}
 		},
 
-		onHide = element => {
-			element.component.closeBtn.removeEventListener( 'click', popup.hide )
-			element.component.readMore.removeEventListener( 'click', onExpand )
+		onHide = () => {
+			clearEventListener()
+			clearAllTimeout()
+			// element.component.closeBtn.removeEventListener( 'click', popup.hide )
+			// element.component.readMore.removeEventListener( 'click', onExpand )
 
-			if ( isTouch ) {
-				document.removeEventListener( 'touchstart', onTouchStart, true )
-			} else {
-				element.removeEventListener( 'mouseleave', onMouseLeave )
-				element.currentTargetElement.removeEventListener( 'mouseleave', onMouseLeave )
-			}
+			// if ( isTouch ) {
+			// document.removeEventListener( 'touchstart', onTouchStart, true )
+			// } else {
+			// element.removeEventListener( 'mouseleave', onMouseLeave )
+			// element.currentTargetElement.removeEventListener( 'mouseleave', onMouseLeave )
+			// }
 		},
 
 		onShow = element => {
@@ -61,14 +79,20 @@ export const customEvents = popup => {
 				onExpand( element )
 			}
 
-			element.component.closeBtn.addEventListener( 'click', popup.hide )
-			element.component.readMore.addEventListener( 'click', onExpand )
+			addEventListener( element.component.closeBtn, 'click', popup.hide )
+			addEventListener( element.component.readMore, 'click', onExpand )
+			// element.component.closeBtn.addEventListener( 'click', popup.hide )
+			// element.component.readMore.addEventListener( 'click', onExpand )
 
 			if ( isTouch ) {
-				document.addEventListener( 'touchstart', onTouchStart, true )
+				// document.addEventListener( 'touchstart', onTouchStart, true )
+				addEventListener( document, 'touchstart', onTouchStart, true )
 			} else {
-				element.addEventListener( 'mouseleave', onMouseLeave )
-				element.currentTargetElement.addEventListener( 'mouseleave', onMouseLeave )
+				addEventListener( element, 'mouseleave', onMouseLeave )
+				addEventListener( element.currentTargetElement, 'mouseleave', onMouseLeave )
+				// element.addEventListener( 'mouseleave', onMouseLeave )
+				// element.currentTargetElement.addEventListener( 'mouseleave', onMouseLeave )
+
 			}
 		}
 

--- a/src/event.js
+++ b/src/event.js
@@ -55,15 +55,6 @@ export const customEvents = popup => {
 		onHide = () => {
 			clearEventListener()
 			clearAllTimeout()
-			// element.component.closeBtn.removeEventListener( 'click', popup.hide )
-			// element.component.readMore.removeEventListener( 'click', onExpand )
-
-			// if ( isTouch ) {
-			// document.removeEventListener( 'touchstart', onTouchStart, true )
-			// } else {
-			// element.removeEventListener( 'mouseleave', onMouseLeave )
-			// element.currentTargetElement.removeEventListener( 'mouseleave', onMouseLeave )
-			// }
 		},
 
 		onShow = element => {
@@ -81,18 +72,12 @@ export const customEvents = popup => {
 
 			addEventListener( element.component.closeBtn, 'click', popup.hide )
 			addEventListener( element.component.readMore, 'click', onExpand )
-			// element.component.closeBtn.addEventListener( 'click', popup.hide )
-			// element.component.readMore.addEventListener( 'click', onExpand )
 
 			if ( isTouch ) {
-				// document.addEventListener( 'touchstart', onTouchStart, true )
 				addEventListener( document, 'touchstart', onTouchStart, true )
 			} else {
 				addEventListener( element, 'mouseleave', onMouseLeave )
 				addEventListener( element.currentTargetElement, 'mouseleave', onMouseLeave )
-				// element.addEventListener( 'mouseleave', onMouseLeave )
-				// element.currentTargetElement.addEventListener( 'mouseleave', onMouseLeave )
-
 			}
 		}
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,10 +16,7 @@ function init( {
 			createPopup( popupContainer ),
 		events = customEvents( popup ),
 		showPopup = ( { target } ) => {
-			if ( popup.timeoutId ) {
-				clearTimeout( popup.timeoutId )
-				popup.timeoutId = null
-			}
+			popup.hide()
 
 			const title = target.getAttribute( 'data-wp-title' ) || target.textContent,
 				lang = target.getAttribute( 'data-wp-lang' ) || globalLang


### PR DESCRIPTION
 PR related to https://github.com/wikimedia/wikipedia-preview/pull/20 
 Comment related to https://github.com/wikimedia/wikipedia-preview/commit/beb4a3a7ca740947214c03e7ee11982697c775a1#commitcomment-40695177

Before we introducing the **delay feature for desktop**, we deal with all the events synchronously, **delay feature** brings the race condition and asynchronous event execution. Also note that there is only one instance of popup, unless we declare popup instance for each new popup event.

Therefore this let us think more about **the order of the event called**, and all of them should be **cleared empty once hide event is called**, this POC shows the following

1. A central place for all the event listener - No more manually remove each event listener, instead, remove ALL
1. A central place for all the timeout - takes care of the timeout event whether it should execute or clear.

Let me know what do you see or foresee any problem.