### PR TITLE
T257645: Switch from touchstart to touchend

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ function init( {
 		root.querySelectorAll( selector ),
 		node => {
 			if ( isTouch ) {
-				node.addEventListener( 'touchstart', showPopup )
+				node.addEventListener( 'touchend', showPopup )
 			} else {
 				node.addEventListener( 'mouseenter', showPopup )
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,10 @@ function init( {
 					if ( isTouch ) {
 						// eslint-disable-next-line no-script-url
 						node.setAttribute( 'href', 'javascript:;' )
+						node.addEventListener( 'touchend', showPopup )
+					} else {
+						node.addEventListener( 'mouseenter', showPopup )
 					}
-					node.addEventListener( 'mouseenter', showPopup )
 				}
 			}
 		)


### PR DESCRIPTION
Phab ticket: https://phabricator.wikimedia.org/T257645

For some reason [1] the `touchstart` event is not working as expected in Chrome, instead `touchend` does. I was able to replicate the same bug behavior description on Chrome in my desktop only (as in through dev tools mobile simulator), and not in Chrome on iphone. With `touchend` I get the expected behavior both on desktop and mobile with Chrome, Firefox and Safari. 

Leaving this TODO here though:

- [ ] We need to test across more devices (Android, Windows Touchable Desktop Browser, etc)

Note that the other `touchstart` event we have (to close popup) is working fine


---

[1]—

https://stackoverflow.com/questions/16703157/android-4-chrome-hit-testing-issue-on-touch-events-after-css-transform
https://benjaminhorn.io/code/touchstart-performance-issues-in-google-chrome/
https://stackoverflow.com/questions/38784878/touchstart-issue-in-chrome-browser
https://stackoverflow.com/questions/18863870/touchstart-event-never-be-triggered-on-android-chrome-at-the-first-time-of-page
