### PR TITLE
IE: use bounding rectangle left/top instead of x/y

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:dev": "webpack --mode development",
     "build:prod": "webpack --mode production",
     "build": "npm run build:dev && npm run build:prod",
-    "dev": "webpack-dev-server --mode development --host=0.0.0.0"
+    "dev": "webpack-dev-server --mode development --host=0.0.0.0 --disable-host-check"
   },
   "author": "Wikimedia Foundation",
   "license": "MIT",

--- a/src/popup.js
+++ b/src/popup.js
@@ -7,11 +7,11 @@ const computePopupPosition = (
 	) => {
 		let left, right = '', top = '', bottom = ''
 
-		left = targetRect.x > ( innerWidth / 2 ) ?
+		left = targetRect.left > ( innerWidth / 2 ) ?
 			( scrollX + targetRect.right - popupWidth ) :
 			( scrollX + targetRect.left )
 
-		if ( targetRect.y > ( innerHeight / 2 ) ) {
+		if ( targetRect.top > ( innerHeight / 2 ) ) {
 			bottom = ( innerHeight - targetRect.top - scrollY )
 		} else {
 			top = ( scrollY + targetRect.bottom )


### PR DESCRIPTION
https://phabricator.wikimedia.org/T256724

In IE 11, the return value of `element.getBoundingClientRect()` doesn't contain `x` or `y` so the popup positioning was wrong (always below and to the right of the target element). This can cause the document width to change, a scrollbar to appear, and the text to reflow.

I think this was causing the issue described in the task but I can't be sure since I cannot reproduce it anymore.

Note: the change to the `dev` command in `package.json` is needed to allow a local connection to be established with crossbrowsertesting.com