### PR TITLE
prevent any default behaviours when showing popup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,12 +16,13 @@ function init( {
 			createTouchPopup( popupContainer ) :
 			createPopup( popupContainer ),
 		events = customEvents( popup ),
-		showPopup = ( { target } ) => {
+		showPopup = ( e ) => {
+			e.preventDefault()
 			if ( popup.element.style.visibility === 'visible' ) {
 				popup.hide()
 			}
-
-			const title = target.getAttribute( 'data-wp-title' ) || target.textContent,
+			const { target } = e,
+				title = target.getAttribute( 'data-wp-title' ) || target.textContent,
 				lang = target.getAttribute( 'data-wp-lang' ) || globalLang
 
 			requestPagePreview( lang, title, isTouch, data => {


### PR DESCRIPTION
It happens to my desktop touchable chrome browser and chrome mobile simulator 

Without this, it can open the gallery or Wikipedia page link accidentally when the popup open and the tap location is exactly the same place of the gallery or page link.