### PR TITLE
Use click to not interfere with scroll

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ function init( {
 		root.querySelectorAll( selector ),
 		node => {
 			if ( isTouch ) {
-				node.addEventListener( 'touchend', showPopup )
+				node.addEventListener( 'click', showPopup )
 			} else {
 				node.addEventListener( 'mouseenter', showPopup )
 			}
@@ -64,7 +64,7 @@ function init( {
 					if ( isTouch ) {
 						// eslint-disable-next-line no-script-url
 						node.setAttribute( 'href', 'javascript:;' )
-						node.addEventListener( 'touchend', showPopup )
+						node.addEventListener( 'click', showPopup )
 					} else {
 						node.addEventListener( 'mouseenter', showPopup )
 					}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T258263

On mobile, the `touchstart`, `touchmove` and `touchend` events fire for every touch interactions (tap or scroll).

The `click` event represent a single tap and does not fire during a scroll gesture.