### PR TITLE
Add fullscreen gallery story to Storybook

### DIFF
--- a/src/stories/gallery.stories.js
+++ b/src/stories/gallery.stories.js
@@ -1,0 +1,58 @@
+import { showFullscreenGallery } from '../gallery'
+
+export default {
+	title: 'Gallery',
+	argTypes: {
+		touch: {
+			name: 'Mobile',
+			defaultValue: false,
+			control: 'boolean'
+		},
+		lang: {
+			name: 'Language',
+			defaultValue: 'en',
+			control: {
+				type: 'select',
+				options: [ 'en', 'fr', 'hi', 'ks', 'he' ]
+			}
+		},
+		dir: {
+			name: 'Direction',
+			defaultValue: 'LTR',
+			control: {
+				type: 'inline-radio',
+				options: [ 'LTR', 'RTL' ]
+			}
+		}
+	}
+}
+
+export const Fullscreen = ( { lang, dir } ) => {
+	const container = document.createElement( 'div' )
+	const mediaItems = [
+		{
+			caption: 'Wikipedia logo',
+			thumb: 'https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Wikipedia-logo-v2.svg/225px-Wikipedia-logo-v2.svg.png',
+			src: 'https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Wikipedia-logo-v2.svg/225px-Wikipedia-logo-v2.svg.png'
+		},
+		{
+			caption: 'Wikipedia Homepage',
+			thumb: 'https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Wikipedia_Main_Page.png/960px-Wikipedia_Main_Page.png',
+			src: 'https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Wikipedia_Main_Page.png/960px-Wikipedia_Main_Page.png'
+		},
+		{
+			caption: 'Wikipedia originally developed from another encyclopedia project called Nupedia',
+			thumb: 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Nupedia_logo_and_wordmark.png/480px-Nupedia_logo_and_wordmark.png',
+			src: 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Nupedia_logo_and_wordmark.png/480px-Nupedia_logo_and_wordmark.png'
+		},
+		{
+			caption: 'The Wikipedia Page on December 17, 2001',
+			thumb: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/English_Wikipedia_main_page_20011217.jpg/480px-English_Wikipedia_main_page_20011217.jpg',
+			src: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/English_Wikipedia_main_page_20011217.jpg/480px-English_Wikipedia_main_page_20011217.jpg'
+
+		}
+	]
+
+	showFullscreenGallery( mediaItems, null, lang, dir, container )
+	return container
+}


### PR DESCRIPTION
Add to a separate section as gallery can used by *any* 

<img width="958" alt="Annotation 2020-08-20 222549" src="https://user-images.githubusercontent.com/2560096/90822283-7c36eb80-e334-11ea-90b4-630f2e4f188a.png">
