### PR TITLE
POC : render example for gallery row

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -1,6 +1,7 @@
 import { isTouch } from './utils'
-import { getGalleryRow } from './gallery'
+import { GalleryRow } from './gallery'
 import { requestPageMedia } from './api'
+import render from './render'
 
 export const customEvents = popup => {
 
@@ -58,7 +59,7 @@ export const customEvents = popup => {
 				requestPageMedia( lang, title, mediaData => {
 					if ( mediaData && mediaData.length > 0 ) {
 						const galleryContainer = popup.element.querySelector( '.wikipediapreview-gallery' )
-						galleryContainer.appendChild( getGalleryRow( mediaData, popup ) )
+						render( GalleryRow( mediaData, popup.lang, popup.dir ), galleryContainer )
 					}
 				} )
 			}

--- a/src/gallery/row.js
+++ b/src/gallery/row.js
@@ -9,7 +9,7 @@ export const GalleryRow = ( mediaItems, lang, dir ) => {
 	return {
 		template: `<div class="wikipediapreview-gallery-row">${images}</div>`,
 		ui: {
-			container: '.wikipediapreview-gallery-image',
+			container: '.wikipediapreview-gallery-row',
 			image: '.wikipediapreview-gallery-image'
 		},
 		events: {

--- a/src/gallery/row.js
+++ b/src/gallery/row.js
@@ -1,21 +1,22 @@
 import { showFullscreenGallery } from './fullscreen'
 
-export const getGalleryRow = ( mediaItems, popup ) => {
-	const galleryRow = document.createElement( 'div' )
-	galleryRow.classList.add( 'wikipediapreview-gallery-row' )
+export const GalleryRow = ( mediaItems, lang, dir ) => {
 
-	mediaItems.forEach( item => {
-		const image = document.createElement( 'div' )
+	const images = mediaItems.map( item => {
+		return `<div class="wikipediapreview-gallery-image" style="background-image:url('${item.thumb}')"></div>`
+	} ).join( '' )
 
-		image.classList.add( 'wikipediapreview-gallery-image' )
-		image.style.backgroundImage = `url(${item.thumb})`
-		image.addEventListener( 'click', ( e ) => {
-			const selected = e.target.style.backgroundImage.slice( 4, -1 ).replace( /"/g, '' )
-			showFullscreenGallery( mediaItems, selected, popup.lang, popup.dir )
-		} )
-
-		galleryRow.appendChild( image )
-	} )
-
-	return galleryRow
+	return {
+		template: `<div class="wikipediapreview-gallery-row">${images}</div>`,
+		ui: {
+			container: '.wikipediapreview-gallery-image',
+			image: '.wikipediapreview-gallery-image'
+		},
+		events: {
+			'image click': e => {
+				const selected = e.target.style.backgroundImage.slice( 4, -1 ).replace( /"/g, '' )
+				showFullscreenGallery( mediaItems, selected, lang, dir )
+			}
+		}
+	}
 }

--- a/src/render.js
+++ b/src/render.js
@@ -1,0 +1,16 @@
+export default ( component, container = document.body ) => {
+	const { template, ui = {}, events = {} } = component
+
+	container.insertAdjacentHTML( 'beforeend', template )
+
+    Object.entries( events ).forEach( entry => { // eslint-disable-line
+		const [ key, action ] = entry,
+			[ uiElement, eventType ] = key.split( ' ' ),
+			targetElements = container.querySelectorAll( ui[ uiElement ] )
+
+		targetElements.forEach( targetElement => {
+			targetElement.addEventListener( eventType, action )
+		} )
+
+	} )
+}

--- a/src/render.js
+++ b/src/render.js
@@ -3,7 +3,7 @@ export default ( component, container = document.body ) => {
 
 	container.insertAdjacentHTML( 'beforeend', template )
 
-    Object.entries( events ).forEach( entry => { // eslint-disable-line
+	Object.entries( events ).forEach( entry => { // eslint-disable-line
 		const [ key, action ] = entry,
 			[ uiElement, eventType ] = key.split( ' ' ),
 			targetElements = container.querySelectorAll( ui[ uiElement ] )

--- a/src/render.js
+++ b/src/render.js
@@ -8,7 +8,7 @@ export default ( component, container = document.body ) => {
 			[ uiElement, eventType ] = key.split( ' ' ),
 			targetElements = container.querySelectorAll( ui[ uiElement ] )
 
-		targetElements.forEach( targetElement => {
+		Array.prototype.forEach.call( targetElements, targetElement => {
 			targetElement.addEventListener( eventType, action )
 		} )
 

--- a/src/stories/preview.stories.js
+++ b/src/stories/preview.stories.js
@@ -1,5 +1,6 @@
 import { renderPreview, renderLoading, renderError, renderDisambiguation } from '../preview'
-import { getGalleryRow } from '../gallery'
+import { GalleryRow } from '../gallery'
+import render from '../render'
 
 export default {
 	title: 'Wikipedia Preview',
@@ -65,7 +66,7 @@ export const Expanded = ( { lang, title, extractHtml, dir, pageUrl, touch } ) =>
 			title: 'title2'
 		}
 	]
-	preview.querySelector( '.wikipediapreview-gallery' ).appendChild( getGalleryRow( mediaData, null ) )
+	render( GalleryRow( mediaData, null ), preview.querySelector( '.wikipediapreview-gallery' ) )
 	return preview
 }
 

--- a/test/gallery.test.js
+++ b/test/gallery.test.js
@@ -1,7 +1,7 @@
 'use strict'
 const assert = require( 'assert' )
 const { JSDOM } = require( 'jsdom' )
-const { showFullscreenGallery, getGalleryRow } = require( '../src/gallery' )
+const { showFullscreenGallery, GalleryRow } = require( '../src/gallery' )
 
 describe( 'showFullscreenGallery', () => {
 	let dom,
@@ -87,6 +87,7 @@ describe( 'showFullscreenGallery', () => {
 } )
 
 describe( 'getGalleryRow', () => {
+	let dom, doc
 	const mediaItems = [
 		{
 			caption: 'The first cat',
@@ -109,9 +110,13 @@ describe( 'getGalleryRow', () => {
 	]
 
 	it( 'correctly constructs mini gallery row', () => {
-		const galleryRow = getGalleryRow( mediaItems )
+		const galleryRow = GalleryRow( mediaItems )
 
-		Array.from( galleryRow.children ).forEach( ( image, index ) => {
+		dom = new JSDOM( galleryRow.template )
+		doc = dom.window.document
+		Array.from(
+			doc.querySelector( galleryRow.ui.container ).children
+		).forEach( ( image, index ) => {
 			const thumb = image.style[ 'background-image' ].slice( 4, -1 )
 			assert.equal( thumb, mediaItems[ index ].thumb )
 			assert.equal( image.className, 'wikipediapreview-gallery-image' )


### PR DESCRIPTION
It solves the same pattern everywhere in each component

**Render util :**
1. Given the container where the elements should render
2. assign the ui element for the class name
3. bind the element event

**Component** (gallery row as the example)
1. Given the template in html string

**There are more to take care, for example** 
 - [ ] Model mode (Ex: Article Summary info in the popup Component)
 - [ ] rerender (replace) when the model change - Virtual Dom change? (Ex: show different article summary)
 - [ ] built-in show/hide/destroy event and allow onShow/onHide/onDestroy event? (Ex: close the fullscreen gallery, hide the popup)
 - [ ] multiple key/action for field `events` (Ex: Chain action?)
 - [ ] Composition for component
 - [ ] etc...

This is just a POC for your reference, and i believe this is a good starting point, idea or use cases are welcomed.