### PR TITLE
T259233: Wikipedia Preview card dragging gestures

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -94,7 +94,7 @@ export const customEvents = popup => {
 				handleTouchEnd = ( isHeader ) => {
 					const expanded = element.querySelector( '.wikipediapreview.expanded' ),
 						delta = initialY - finalY,
-						isOverThreshold = Math.abs( delta ) > 60,
+						isOverThreshold = Math.abs( delta ) > 80,
 						isNotExpandedBody = !expanded && !isHeader || isHeader
 
 					if ( delta < 0 && isOverThreshold && isNotExpandedBody ) {

--- a/src/event.js
+++ b/src/event.js
@@ -67,15 +67,15 @@ export const customEvents = popup => {
 		applyDragEvent = ( element ) => {
 			let initialY,
 				finalY,
-				containerBodyStyle,
+				previewBodyStyle,
 				initialHeight
 
-			const containerHeader = element.querySelector( '.wikipediapreview-header' ),
-				containerBody = element.querySelector( '.wikipediapreview-body' ),
+			const previewHeader = element.querySelector( '.wikipediapreview-header' ),
+				previewBody = element.querySelector( '.wikipediapreview-body' ),
 				handleTouchStart = ( e ) => {
 					initialY = e.touches[ 0 ].clientY
-					containerBodyStyle = window.getComputedStyle( containerBody )
-					initialHeight = Number( containerBodyStyle.height.slice( 0, -2 ) )
+					previewBodyStyle = window.getComputedStyle( previewBody )
+					initialHeight = Number( previewBodyStyle.height.slice( 0, -2 ) )
 				},
 
 				handleTouchMove = ( e, isHeader ) => {
@@ -87,7 +87,7 @@ export const customEvents = popup => {
 
 					finalY = clientY
 					if ( isNotExpandedBody ) {
-						containerBody.style.maxHeight = currentHeight + 'px'
+						previewBody.style.maxHeight = currentHeight + 'px'
 					}
 				},
 
@@ -100,24 +100,24 @@ export const customEvents = popup => {
 					if ( delta < 0 && isOverThreshold && isNotExpandedBody ) {
 						popup.hide()
 					} else if ( delta > 0 && isOverThreshold && isNotExpandedBody && !expanded ) {
-						containerBody.style.maxHeight = '70vh'
+						previewBody.style.maxHeight = '70vh'
 						onExpand()
 					} else {
-						containerBody.style.maxHeight = initialHeight + 'px'
+						previewBody.style.maxHeight = initialHeight + 'px'
 					}
 				}
 
-			addEventListener( containerBody, 'touchstart', handleTouchStart )
-			addEventListener( containerBody, 'touchmove', ( e ) => {
+			addEventListener( previewBody, 'touchstart', handleTouchStart )
+			addEventListener( previewBody, 'touchmove', ( e ) => {
 				handleTouchMove( e, false )
 			} )
-			addEventListener( containerBody, 'touchend', () => handleTouchEnd( false ) )
+			addEventListener( previewBody, 'touchend', () => handleTouchEnd( false ) )
 
-			addEventListener( containerHeader, 'touchstart', handleTouchStart )
-			addEventListener( containerHeader, 'touchmove', ( e ) => {
+			addEventListener( previewHeader, 'touchstart', handleTouchStart )
+			addEventListener( previewHeader, 'touchmove', ( e ) => {
 				handleTouchMove( e, true )
 			} )
-			addEventListener( containerHeader, 'touchend', () => handleTouchEnd( true ) )
+			addEventListener( previewHeader, 'touchend', () => handleTouchEnd( true ) )
 		},
 
 		onHide = () => {

--- a/src/event.js
+++ b/src/event.js
@@ -66,25 +66,41 @@ export const customEvents = popup => {
 
 		applyDragEvent = ( element ) => {
 			let detectedCoordinates = {
-				initialY: null,
-				finalY: null
+				dragUpInitialY: null,
+				dragUpFinalY: null,
+				dragDownInitialY: null,
+				dragDownFinalY: null
 			}
 
-			const container = element.component.wikipediapreview
+			const container = element.component.wikipediapreview,
+				containerHeader = element.querySelector( '.wikipediapreview-header' )
 
 			container.addEventListener( 'touchstart', e => {
-				detectedCoordinates.initialY = e.touches[ 0 ].clientY
+				detectedCoordinates.dragUpInitialY = e.touches[ 0 ].clientY
 			} )
 			container.addEventListener( 'touchmove', e => {
-				detectedCoordinates.finalY = e.touches[ 0 ].clientY
+				detectedCoordinates.dragUpFinalY = e.touches[ 0 ].clientY
 			} )
 			container.addEventListener( 'touchend', () => {
 				const expanded = element.querySelector( '.wikipediapreview.expanded' ),
-					delta = detectedCoordinates.initialY - detectedCoordinates.finalY
+					delta = detectedCoordinates.dragUpInitialY - detectedCoordinates.dragUpFinalY
 
 				if ( !expanded && delta > 0 ) {
 					onExpand()
-				} else if ( delta < 0 && Math.abs( delta ) > 80 ) {
+				}
+			} )
+
+			containerHeader.addEventListener( 'touchstart', e => {
+				detectedCoordinates.dragDownInitialY = e.touches[ 0 ].clientY
+			} )
+			containerHeader.addEventListener( 'touchmove', e => {
+				detectedCoordinates.dragDownFinalY = e.touches[ 0 ].clientY
+			} )
+			containerHeader.addEventListener( 'touchend', () => {
+				const expanded = element.querySelector( '.wikipediapreview.expanded' ),
+					delta = detectedCoordinates.dragDownInitialY - detectedCoordinates.dragDownFinalY
+
+				if ( expanded && delta < 0 && Math.abs( delta ) > 80 ) {
 					popup.hide()
 				}
 			} )

--- a/src/event.js
+++ b/src/event.js
@@ -82,10 +82,11 @@ export const customEvents = popup => {
 					const clientY = e.touches[ 0 ].clientY,
 						offset = initialY - clientY,
 						currentHeight = initialHeight + offset,
-						expanded = element.querySelector( '.wikipediapreview.expanded' )
+						expanded = element.querySelector( '.wikipediapreview.expanded' ),
+						isNotExpandedBody = !expanded && !isHeader || isHeader
 
 					finalY = clientY
-					if ( !isHeader && !expanded || isHeader && expanded ) {
+					if ( isNotExpandedBody ) {
 						containerBody.style.maxHeight = currentHeight + 'px'
 					}
 				},
@@ -93,11 +94,12 @@ export const customEvents = popup => {
 				handleTouchEnd = ( isHeader ) => {
 					const expanded = element.querySelector( '.wikipediapreview.expanded' ),
 						delta = initialY - finalY,
-						isOverThreshold = Math.abs( delta ) > 60
+						isOverThreshold = Math.abs( delta ) > 60,
+						isNotExpandedBody = !expanded && !isHeader || isHeader
 
-					if ( isHeader && expanded && delta < 0 && isOverThreshold ) {
+					if ( delta < 0 && isOverThreshold && isNotExpandedBody ) {
 						popup.hide()
-					} else if ( !isHeader && !expanded && delta > 0 && isOverThreshold ) {
+					} else if ( delta > 0 && isOverThreshold && isNotExpandedBody && !expanded ) {
 						containerBody.style.maxHeight = '70vh'
 						onExpand()
 					} else {

--- a/src/event.js
+++ b/src/event.js
@@ -70,8 +70,7 @@ export const customEvents = popup => {
 				containerBodyStyle,
 				initialHeight
 
-			const container = element.component.wikipediapreview,
-				containerHeader = element.querySelector( '.wikipediapreview-header' ),
+			const containerHeader = element.querySelector( '.wikipediapreview-header' ),
 				containerBody = element.querySelector( '.wikipediapreview-body' ),
 				handleTouchStart = ( e ) => {
 					initialY = e.touches[ 0 ].clientY
@@ -106,11 +105,11 @@ export const customEvents = popup => {
 					}
 				}
 
-			addEventListener( container, 'touchstart', handleTouchStart )
-			addEventListener( container, 'touchmove', ( e ) => {
+			addEventListener( containerBody, 'touchstart', handleTouchStart )
+			addEventListener( containerBody, 'touchmove', ( e ) => {
 				handleTouchMove( e, false )
 			} )
-			addEventListener( container, 'touchend', () => handleTouchEnd( false ) )
+			addEventListener( containerBody, 'touchend', () => handleTouchEnd( false ) )
 
 			addEventListener( containerHeader, 'touchstart', handleTouchStart )
 			addEventListener( containerHeader, 'touchmove', ( e ) => {

--- a/src/event.js
+++ b/src/event.js
@@ -64,7 +64,7 @@ export const customEvents = popup => {
 			}
 		},
 
-		applySwipeEvent = ( element ) => {
+		applyDragEvent = ( element ) => {
 			let detectedCoordinates = {
 				initialY: null,
 				finalY: null
@@ -123,7 +123,7 @@ export const customEvents = popup => {
 			if ( isTouch ) {
 				const darkScreen = document.querySelector( '.wp-dark-screen' )
 				addEventListener( darkScreen, 'click', popup.hide, true )
-				applySwipeEvent( element )
+				applyDragEvent( element )
 			} else {
 				addEventListener( element, 'mouseleave', onMouseLeave )
 				addEventListener( element.currentTargetElement, 'mouseleave', onMouseLeave )

--- a/src/event.js
+++ b/src/event.js
@@ -85,6 +85,7 @@ export const customEvents = popup => {
 						expanded = element.querySelector( '.wikipediapreview.expanded' ),
 						isNotExpandedBody = !expanded && !isHeader || isHeader
 
+					previewBody.style.transition = 'unset'
 					finalY = clientY
 					if ( isNotExpandedBody ) {
 						previewBody.style.maxHeight = currentHeight + 'px'
@@ -97,6 +98,7 @@ export const customEvents = popup => {
 						isOverThreshold = Math.abs( delta ) > 80,
 						isNotExpandedBody = !expanded && !isHeader || isHeader
 
+					previewBody.style.transition = 'all 0.25s ease-in-out'
 					if ( delta < 0 && isOverThreshold && isNotExpandedBody ) {
 						popup.hide()
 					} else if ( delta > 0 && isOverThreshold && isNotExpandedBody && !expanded ) {
@@ -125,6 +127,9 @@ export const customEvents = popup => {
 			popup.lang = null
 			popup.title = null
 			popup.loading = false
+
+			const previewBody = popup.element.component.wikipediapreview.querySelector( '.wikipediapreview-body' )
+			previewBody.style.transition = 'unset'
 
 			clearAllEventListener()
 			clearAllTimeout()

--- a/src/event.js
+++ b/src/event.js
@@ -64,6 +64,32 @@ export const customEvents = popup => {
 			}
 		},
 
+		applySwipeEvent = ( element ) => {
+			let detectedCoordinates = {
+				initialY: null,
+				finalY: null
+			}
+
+			const container = element.component.wikipediapreview
+
+			container.addEventListener( 'touchstart', e => {
+				detectedCoordinates.initialY = e.touches[ 0 ].clientY
+			} )
+			container.addEventListener( 'touchmove', e => {
+				detectedCoordinates.finalY = e.touches[ 0 ].clientY
+			} )
+			container.addEventListener( 'touchend', () => {
+				const expanded = element.querySelector( '.wikipediapreview.expanded' ),
+					delta = detectedCoordinates.initialY - detectedCoordinates.finalY
+
+				if ( !expanded && delta > 0 ) {
+					onExpand()
+				} else if ( delta < 0 && Math.abs( delta ) > 80 ) {
+					popup.hide()
+				}
+			} )
+		},
+
 		onHide = () => {
 			popup.element.component.wikipediapreview.classList.remove( 'expanded' )
 			popup.lang = null
@@ -97,6 +123,7 @@ export const customEvents = popup => {
 			if ( isTouch ) {
 				const darkScreen = document.querySelector( '.wp-dark-screen' )
 				addEventListener( darkScreen, 'click', popup.hide, true )
+				applySwipeEvent( element )
 			} else {
 				addEventListener( element, 'mouseleave', onMouseLeave )
 				addEventListener( element.currentTargetElement, 'mouseleave', onMouseLeave )

--- a/src/preview.js
+++ b/src/preview.js
@@ -32,7 +32,7 @@ const renderPreview = ( lang, data, isTouch ) => {
 						<div class="wikipediapreview-header-closebtn"></div>
 					</div>
 					<div class="wikipediapreview-loading">
-						<div class="wikipediapreview-loading-body">
+						<div class="wikipediapreview-body">
 							<div class="wikipediapreview-loading-body-line larger"></div>
 							<div class="wikipediapreview-loading-body-line medium"></div>
 							<div class="wikipediapreview-loading-body-line larger"></div>

--- a/style/preview.less
+++ b/style/preview.less
@@ -124,8 +124,6 @@
 	}
 
 	&-loading {
-		height: 250px;
-
 		&-header-image {
 			background-image: inline-svg( '../images/loading-thumb.svg' );
 			background-size: auto;


### PR DESCRIPTION
https://phabricator.wikimedia.org/T259233

# Problem

Currently, users need to tap 'Continue reading' button expand preview card. We would like to improve the user experience by allowing users to also be able to drag on mobile to interact with preview card

# Solution

Allow users to drag up to expand preview card, drag down to close it, following specified requirements:

- To drag up and reveal more content, user should be able to drag up from either the body or header of the card
- To drag down and close the Wikipedia Preview card, users should only be able to drag down the card header. This is to not interfere with any possible text scrolling
- The tap gesture should remain unchanged

Solution inspired from #56 

---

#### TODOs

- [x] Design clarification: swipe up initial touch position
- [x] Design clarification: swipe down gesture when scrolling text is present
