### PR TITLE
T260436: improve detectLinks non-latin support 

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -2,10 +2,10 @@ export const getWikipediaAttrFromUrl = url => {
 		const regexList = [
 			// https://zh.wikipedia.org/wiki/前岐镇"
 			// https://en.wikipedia.org/wiki/Cat#Section
-			/^https?:\/\/(\w+)(\.m)?\.wikipedia\.org\/wiki\/([^#?\u0180-\u024F]+)/,
+			/^https?:\/\/(\w+)(\.m)?\.wikipedia\.org\/wiki\/([^#?]+)/,
 			// https://en.wikipedia.org/w/index.php?title=Cat
 			// https://zh.wikipedia.org/w/index.php?title=太阳帆&action=purge
-			/^https?:\/\/(\w+)(\.m)?\.wikipedia\.org\/w\/index.php\?title=([^&\u0180-\u024F]+)/
+			/^https?:\/\/(\w+)(\.m)?\.wikipedia\.org\/w\/index.php\?title=([^#&]+)/
 		]
 
 		for ( let i = 0; i < regexList.length; i++ ) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -21,6 +21,8 @@ describe( 'getWikipediaAttrFromUrl', () => {
 		{ url: 'https://en.wikipedia.org/wiki/Ā', expected: { lang: 'en', mobile: false, title: 'Ā' } },
 		{ url: 'https://it.wikipedia.org/wiki/Željko_Obradović', expected: { lang: 'it', mobile: false, title: 'Željko_Obradović' } },
 		{ url: 'https://en.wikipedia.org/wiki/&Burn', expected: { lang: 'en', mobile: false, title: '&Burn' } },
+		{ url: 'https://en.wikipedia.org/wiki/ȏ', expected: { lang: 'en', mobile: false, title: 'ȏ' } },
+		{ url: 'https://en.wikipedia.org/w/index.php?title=?!_(album)', expected: { lang: 'en', mobile: false, title: '?!_(album)' } },
 		{ url: 'https://wikimediafoundation.org/', expected: null }
 	]
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T260436

This is a follow-up for #54, one more update to address [the remaining failing test](https://phabricator.wikimedia.org/T260436#6431566)

```
wikipedia-previews % npm test test/utils.test.js

> wikipedia-preview@1.0.3 test /Users/emedina/internet/wikimedia/wikipedia-previews
> mocha --require ignore-styles,@babel/register,jsdom-global/register "test/utils.test.js"



  getWikipediaAttrFromUrl
    ✓ checks https://en.wikipedia.org/wiki/Cat
    ✓ checks https://en.m.wikipedia.org/wiki/Cat
    ✓ checks https://he.wikipedia.org/wiki/ירח
    ✓ checks https://he.wikipedia.org/wiki/ירח#Section
    ✓ checks https://ru.wikipedia.org/wiki/Каменобродский,_Альфред_Адольфович
    ✓ checks https://zh.wikipedia.org/wiki/太阳帆
    ✓ checks https://zh.wikipedia.org/w/index.php?title=太阳帆&action=purge
    ✓ checks https://ar.wikipedia.org/wiki/كلية_التربية_النوعية_(جامعة_أسوان)
    ✓ checks https://en.wikipedia.org/wiki/Cat#Section
    ✓ checks https://en.wikipedia.org/wiki/Cat?action=edit
    ✓ checks https://de.wikipedia.org/w/index.php?title=Katze
    ✓ checks https://en.m.wikipedia.org/w/index.php?title=Cat&uselang=de
    ✓ checks https://es.wikipedia.org/wiki/82.ª_División_Aerotransportada
    ✓ checks https://en.wikipedia.org/wiki/Ā
    ✓ checks https://it.wikipedia.org/wiki/Željko_Obradović
    ✓ checks https://en.wikipedia.org/wiki/&Burn
    ✓ checks https://en.wikipedia.org/wiki/ȏ
    ✓ checks https://en.wikipedia.org/w/index.php?title=?!_(album)
    ✓ checks https://wikimediafoundation.org/


  19 passing (8ms)
```