### PR TITLE
T257648 Desktop expand preview popup layout (max height calculation)

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -49,10 +49,24 @@ export const customEvents = popup => {
 		},
 
 		onExpand = () => {
+
+			const bodyElement = popup.element.querySelector( '.wikipediapreview-body' ),
+				maxHeight = 496,
+				{ lang, title } = popup
+
 			popup.element.component.wikipediapreview.classList.add( 'expanded' )
 
-			const lang = popup.lang,
-				title = popup.title
+			// expand up
+			if ( popup.element.style[ 2 ] === 'bottom' ) {
+				let currentTop = popup.element.getBoundingClientRect().top,
+					originalHeight = parseInt(
+						window.getComputedStyle( bodyElement ).maxHeight.slice( 0, -2 )
+					)
+				bodyElement.style.maxHeight = Math.min( maxHeight, originalHeight + currentTop ) + 'px'
+			} else {
+				// expand down
+				bodyElement.style.maxHeight = maxHeight + 'px'
+			}
 
 			if ( lang && title ) {
 				requestPageMedia( lang, title, mediaData => {

--- a/src/event.js
+++ b/src/event.js
@@ -56,16 +56,18 @@ export const customEvents = popup => {
 
 			popup.element.component.wikipediapreview.classList.add( 'expanded' )
 
-			// expand up
-			if ( popup.element.style[ 2 ] === 'bottom' ) {
-				let currentTop = popup.element.getBoundingClientRect().top,
-					originalHeight = parseInt(
-						window.getComputedStyle( bodyElement ).maxHeight.slice( 0, -2 )
-					)
-				bodyElement.style.maxHeight = Math.min( maxHeight, originalHeight + currentTop ) + 'px'
-			} else {
-				// expand down
-				bodyElement.style.maxHeight = maxHeight + 'px'
+			if ( !isTouch ) {
+				// expand up
+				if ( popup.element.style[ 2 ] === 'bottom' ) {
+					let currentTop = popup.element.getBoundingClientRect().top,
+						originalHeight = parseInt(
+							window.getComputedStyle( bodyElement ).maxHeight.slice( 0, -2 )
+						)
+					bodyElement.style.maxHeight = Math.min( maxHeight, originalHeight + currentTop ) + 'px'
+				} else {
+					// expand down
+					bodyElement.style.maxHeight = maxHeight + 'px'
+				}
 			}
 
 			if ( lang && title ) {

--- a/style/preview.less
+++ b/style/preview.less
@@ -309,8 +309,9 @@
 
 	&.expanded {
 		.wikipediapreview-body {
-			max-height: 496px;
-			overflow: hidden;
+			// calculate the max height in onExpand()
+			// max-height: 496px;
+			overflow: scroll;
 
 			&:after {
 				content: none;


### PR DESCRIPTION
Phabricator Ticket : https://phabricator.wikimedia.org/T257648

Problem: 

The preview popup may overflow behind the address bar when it expands.

Solution:

Fix the preview popup fix under the address bar when it exceeds the maximum height for the preview body

tested on

- [x] chrome
- [x] firefox
- [x] IE 11
- [x] Edge