### PR TITLE
T261745: gallery with best fit image

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,5 @@
 import { cachedRequest } from './cachedRequest'
-import { buildMwApiUrl, buildCommonsApiUrl, convertUrlToMobile, strip } from './utils'
+import { buildMwApiUrl, buildCommonsApiUrl, convertUrlToMobile, strip, getDeviceSize } from './utils'
 
 const requestPagePreview = ( lang, title, isTouch, callback, request = cachedRequest ) => {
 		const url = `https://${lang}.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent( title )}`
@@ -54,6 +54,8 @@ const requestPagePreview = ( lang, title, isTouch, callback, request = cachedReq
 				iiextmetadatafilter: 'License|LicenseShortName|ImageDescription|Artist',
 				iiextmetadatalanguage: lang,
 				iiextmetadatamultilang: 1,
+				iiurlwidth: getDeviceSize().width,
+				iiurlheight: getDeviceSize().height,
 				iiprop: 'url|extmetadata',
 				titles: title
 			},
@@ -74,13 +76,15 @@ const requestPagePreview = ( lang, title, isTouch, callback, request = cachedReq
 					( typeof ImageDescription.value === 'string' && ImageDescription.value ) ||
 					( ImageDescription.value[ lang ] ||
 						ImageDescription.value[ Object.keys( ImageDescription.value )[ 0 ] ] )
-				)
+				),
+				imageUrl = imageInfo[ 0 ].thumburl
 
 			return {
 				author,
 				description,
 				license: LicenseShortName && LicenseShortName.value,
-				filePage: convertUrlToMobile( imageInfo[ 0 ].descriptionshorturl )
+				filePage: convertUrlToMobile( imageInfo[ 0 ].descriptionshorturl ),
+				bestFitImageUrl: imageUrl
 			}
 		}, callback )
 	}

--- a/src/api.js
+++ b/src/api.js
@@ -28,13 +28,11 @@ const requestPagePreview = ( lang, title, isTouch, callback, request = cachedReq
 			const pageMedia = mediaListData.items.reduce( ( mediaArray, item ) => {
 				if ( item.showInGallery && item.type === 'image' ) {
 					const thumbnail = item && item.srcset && `https:${item.srcset[ 0 ].src}`,
-						source = thumbnail.slice( 0, thumbnail.lastIndexOf( '/' ) ).replace( '/thumb', '' ),
 						media = {
 							caption: item.caption && item.caption.text.trim(),
-							src: source,
 							thumb: thumbnail,
 							title: item.title,
-							fromCommon: source.indexOf( '/commons' ) !== -1
+							fromCommon: thumbnail.indexOf( '/commons' ) !== -1
 						}
 
 					return mediaArray.concat( media )

--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -140,7 +140,6 @@ const clientWidth = window.innerWidth,
 
 				// image
 				item.insertAdjacentHTML( 'beforeend', `<img src="${gallery[ index ].src}"/>` )
-				item.style.backgroundImage = `url("${gallery[ index ].src}")`
 				bindImageEvent( item )
 
 				// image info - caption / attribution
@@ -153,6 +152,8 @@ const clientWidth = window.innerWidth,
 							'beforeend',
 							renderImageInfo( mediaInfo, gallery[ index ], lang
 							) )
+
+						item.style.backgroundImage = `url("${mediaInfo.bestFitImageUrl}")`
 					} )
 			}
 		}

--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -77,7 +77,9 @@ const clientWidth = window.innerWidth,
 
 		// @todo consider a wrapper container for all the image info?
 		return `
-			<div class="${prefixClassname}-item-caption">${getImageDescription()}</div>
+			<div class="${prefixClassname}-item-caption">
+				<div class="${prefixClassname}-item-caption-text">${getImageDescription()}</div>
+			</div>
 			<div class="${prefixClassname}-item-attribution">
 				<div class="${prefixClassname}-item-attribution-info">
 					${getLicenseInfo( mediaInfo.license )}
@@ -125,7 +127,6 @@ const clientWidth = window.innerWidth,
 					bindImageEvent( container, true )
 				} )
 			} )
-
 		}
 	},
 
@@ -135,27 +136,22 @@ const clientWidth = window.innerWidth,
 			item = items[ index ]
 
 		if ( item ) {
-			const imageElement = item.querySelector( 'img' )
-			if ( !imageElement ) {
+			requestPageMediaInfo(
+				lang,
+				gallery[ index ].title,
+				gallery[ index ].fromCommon,
+				mediaInfo => {
+					const imageElement = item.querySelector( 'img' )
+					if ( !imageElement ) {
+						item.insertAdjacentHTML( 'beforeend', `<img src="${mediaInfo.bestFitImageUrl}"/>` )
+						bindImageEvent( item )
+					}
 
-				// image
-				item.insertAdjacentHTML( 'beforeend', `<img src="${gallery[ index ].src}"/>` )
-				bindImageEvent( item )
-
-				// image info - caption / attribution
-				requestPageMediaInfo(
-					lang,
-					gallery[ index ].title,
-					gallery[ index ].fromCommon,
-					mediaInfo => {
-						item.insertAdjacentHTML(
-							'beforeend',
-							renderImageInfo( mediaInfo, gallery[ index ], lang
-							) )
-
-						item.style.backgroundImage = `url("${mediaInfo.bestFitImageUrl}")`
-					} )
-			}
+					item.insertAdjacentHTML(
+						'beforeend',
+						renderImageInfo( mediaInfo, gallery[ index ], lang
+						) )
+				} )
 		}
 	},
 

--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -10,23 +10,24 @@ let current = 0,
 
 const clientWidth = window.innerWidth,
 	prefixClassname = 'wp-gallery-fullscreen-slider',
+
 	renderImageSlider = ( images = [], selectedImage = '', givenLang, givenDir, container ) => {
 		const imageListHtml = images.map( () => `
-                <div class="${prefixClassname}-item">
-                    <div class="${prefixClassname}-item-loading">
-                        <div class="${prefixClassname}-item-loading-spinner">
-                            <div class="${prefixClassname}-item-loading-spinner-animation">
-                                <div class="${prefixClassname}-item-loading-spinner-animation-bounce"></div>
-                            </div>
-                        </div>
-                        <div class="${prefixClassname}-item-loading-text">${msg( givenLang, 'gallery-loading-still' )}</div>
-                    </div>
-                    <div class="${prefixClassname}-item-loading-error">
+			<div class="${prefixClassname}-item">
+					<div class="${prefixClassname}-item-loading">
+							<div class="${prefixClassname}-item-loading-spinner">
+									<div class="${prefixClassname}-item-loading-spinner-animation">
+											<div class="${prefixClassname}-item-loading-spinner-animation-bounce"></div>
+									</div>
+							</div>
+							<div class="${prefixClassname}-item-loading-text">${msg( givenLang, 'gallery-loading-still' )}</div>
+					</div>
+					<div class="${prefixClassname}-item-loading-error">
 						<div class="${prefixClassname}-item-loading-error-text">${msg( givenLang, 'gallery-loading-error' )}</div>
 						<div class="${prefixClassname}-item-loading-error-refresh">${msg( givenLang, 'gallery-loading-error-refresh' )}</div>
 					</div>
-                </div>
-                `.trim()
+			</div>
+			`.trim()
 		).join( '' )
 
 		images.some( ( image, index ) => {
@@ -42,12 +43,12 @@ const clientWidth = window.innerWidth,
 		parentContainer = container
 
 		return `
-            <div class="${prefixClassname}" style="${dir === 'ltr' ? 'margin-left' : 'margin-right'}:-${current * clientWidth}px">
-                <div class="${prefixClassname}-button previous"></div>
-                <div class="${prefixClassname}-button next"></div>
-                ${imageListHtml}
-            </div>
-        `.trim()
+			<div class="${prefixClassname}" style="${dir === 'ltr' ? 'margin-left' : 'margin-right'}:-${current * clientWidth}px">
+					<div class="${prefixClassname}-button previous"></div>
+					<div class="${prefixClassname}-button next"></div>
+					${imageListHtml}
+			</div>
+			`.trim()
 	},
 
 	renderImageInfo = ( mediaInfo, image, lang ) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,4 +55,8 @@ export const getWikipediaAttrFromUrl = url => {
 	strip = html => {
 		const doc = new window.DOMParser().parseFromString( html, 'text/html' )
 		return doc.body.textContent || ''
+	},
+
+	getDeviceSize = () => {
+		return { height: window.innerHeight, width: window.innerWidth }
 	}

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -59,7 +59,7 @@
 		display: flex;
 		display: -ms-flex;
 		max-width: 100%;
-		height: 80vh;
+		height: 100%;
 	}
 
 	&-slider {
@@ -73,7 +73,7 @@
 
 		&-item {
 			width: calc( 100vw );
-			height: calc( 100% - 64px );
+			height: calc( 100% );
 			display: flex;
 			display: -ms-flex;
 			align-items: center;
@@ -84,13 +84,14 @@
 			background-position: center;
 
 			img {
-				visibility: hidden;
+				background-color: #fff;
 			}
 
 			&-caption {
 				position: absolute;
+				background-color: #222;
 				bottom: 35px;
-				width: calc( 100vw - 32px );
+				width: calc( 100vw + 1px );
 				font-size: 16px;
 				font-weight: normal;
 				font-stretch: normal;
@@ -101,6 +102,11 @@
 				overflow: scroll;
 				height: 80px;
 
+				&-text {
+					padding-left: 13px;
+					padding-right: 13px;
+				}
+
 				&::-webkit-scrollbar {
 					display: none;
 				}
@@ -108,8 +114,9 @@
 
 			&-attribution {
 				position: absolute;
+				background-color: #222;
 				bottom: 0;
-				width: calc( 100vw - 32px );
+				width: 100%;
 				font-size: 16px;
 				font-weight: normal;
 				font-stretch: normal;
@@ -121,7 +128,8 @@
 				display: flex;
 				display: -ms-flex;
 				justify-content: space-between;
-				margin-bottom: 15px;
+				padding-bottom: 15px;
+				padding-left: 20px;
 
 				&-info {
 					display: flex;
@@ -174,6 +182,7 @@
 					background-image: inline-svg( '../images/attribution-icon-info.svg' );
 					background-repeat: no-repeat;
 					background-position: center;
+					padding-right: 20px;
 
 					&-link {
 						display: block;
@@ -319,14 +328,14 @@
 				background-image: inline-svg( '../images/arrow-left.svg' );
 				left: 16px;
 				top: 0;
-				height: calc( 70vh );
+				height: 100%;
 				-webkit-tap-highlight-color: transparent;
 			}
 
 			&.next {
 				background-image: inline-svg( '../images/arrow-right.svg' );
 				right: 16px;
-				height: calc( 70vh );
+				height: 100%;
 				-webkit-tap-highlight-color: transparent;
 			}
 		}

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -126,14 +126,12 @@ describe( 'requestPageMedia', () => {
 				caption: 'Cats are popular within internet culture for some reason',
 				fromCommon: false,
 				thumb: 'https://wikimedia.org/thumb/cat.jpg/640px-cat.jpg',
-				src: 'https://wikimedia.org/cat.jpg',
 				title: 'File:Cat_poster_1.jpg'
 			},
 			{
 				caption: 'Skulls of a wildcat (top left) and a housecat (top right)',
 				fromCommon: false,
 				thumb: 'https://wikimedia.org/thumb/cat-skull.jpg/640px-cat-skull.jpg',
-				src: 'https://wikimedia.org/cat-skull.jpg',
 				title: 'File:Cat_skull_1.jpg'
 			}
 		]
@@ -190,14 +188,12 @@ describe( 'requestPageMedia', () => {
 				caption: undefined,
 				fromCommon: false,
 				thumb: 'https://wikimedia.org/thumb/cat.jpg/640px-cat.jpg',
-				src: 'https://wikimedia.org/cat.jpg',
 				title: 'File:Cat_poster_1.jpg'
 			},
 			{
 				caption: undefined,
 				fromCommon: false,
 				thumb: 'https://wikimedia.org/thumb/cat-skull.jpg/640px-cat-skull.jpg',
-				src: 'https://wikimedia.org/cat-skull.jpg',
 				title: 'File:Cat_skull_1.jpg'
 			}
 		]
@@ -239,6 +235,9 @@ describe( 'requestPageMediaInfo', () => {
 						imagerepository: 'local',
 						imageinfo: [
 							{
+								thumburl:	'https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/Horn_Louvre_OA4069.jpg/375px-Horn_Louvre_OA4069.jpg',
+								thumbwidth:	375,
+								thumbheight: 218,
 								url: 'https://upload.wikimedia.org/wikipedia/commons/0/08/Horn_Louvre_OA4069.jpg',
 								descriptionurl: 'https://commons.wikimedia.org/wiki/File:Horn_Louvre_OA4069.jpg',
 								descriptionshorturl: 'https://commons.wikimedia.org/w/index.php?curid=916963',
@@ -276,6 +275,7 @@ describe( 'requestPageMediaInfo', () => {
 			author: '\nUnknown artist\n',
 			description: 'Olifant. Ivory, southern Italy, late 11th century.',
 			filePage: 'https://commons.m.wikimedia.org/w/index.php?curid=916963',
+			bestFitImageUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/Horn_Louvre_OA4069.jpg/375px-Horn_Louvre_OA4069.jpg',
 			license: 'Public domain'
 		}
 		requestPageMediaInfo( 'en', 'title', true, ( data ) => {
@@ -305,6 +305,9 @@ describe( 'requestPageMediaInfo', () => {
 						imagerepository: 'local',
 						imageinfo: [
 							{
+								thumburl:	'https://upload.wikimedia.org/wikipedia/sw/thumb/d/d7/Dunia_muundo.png',
+								thumbwidth:	375,
+								thumbheight: 218,
 								url: 'https://upload.wikimedia.org/wikipedia/sw/d/d7/Dunia_muundo.png',
 								descriptionurl: 'https://sw.wikipedia.org/wiki/Picha:Dunia_muundo.png',
 								descriptionshorturl: 'https://sw.wikipedia.org/w/index.php?curid=5145',
@@ -319,6 +322,7 @@ describe( 'requestPageMediaInfo', () => {
 			author: undefined,
 			description: undefined,
 			filePage: 'https://sw.m.wikipedia.org/w/index.php?curid=5145',
+			bestFitImageUrl: 'https://upload.wikimedia.org/wikipedia/sw/thumb/d/d7/Dunia_muundo.png',
 			license: undefined
 		}
 		requestPageMediaInfo( 'en', 'title', false, ( data ) => {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -235,8 +235,8 @@ describe( 'requestPageMediaInfo', () => {
 						imagerepository: 'local',
 						imageinfo: [
 							{
-								thumburl:	'https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/Horn_Louvre_OA4069.jpg/375px-Horn_Louvre_OA4069.jpg',
-								thumbwidth:	375,
+								thumburl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/Horn_Louvre_OA4069.jpg/375px-Horn_Louvre_OA4069.jpg',
+								thumbwidth: 375,
 								thumbheight: 218,
 								url: 'https://upload.wikimedia.org/wikipedia/commons/0/08/Horn_Louvre_OA4069.jpg',
 								descriptionurl: 'https://commons.wikimedia.org/wiki/File:Horn_Louvre_OA4069.jpg',
@@ -305,8 +305,8 @@ describe( 'requestPageMediaInfo', () => {
 						imagerepository: 'local',
 						imageinfo: [
 							{
-								thumburl:	'https://upload.wikimedia.org/wikipedia/sw/thumb/d/d7/Dunia_muundo.png',
-								thumbwidth:	375,
+								thumburl: 'https://upload.wikimedia.org/wikipedia/sw/thumb/d/d7/Dunia_muundo.png',
+								thumbwidth: 375,
 								thumbheight: 218,
 								url: 'https://upload.wikimedia.org/wikipedia/sw/d/d7/Dunia_muundo.png',
 								descriptionurl: 'https://sw.wikipedia.org/wiki/Picha:Dunia_muundo.png',

--- a/test/gallery.test.js
+++ b/test/gallery.test.js
@@ -60,10 +60,10 @@ describe( 'showFullscreenGallery', () => {
 			images = fullscreenGallery.querySelectorAll( 'img' )
 
 		assert.ok( fullscreenGallery )
-		images.forEach( ( image, index) => {
+		images.forEach( ( image, index ) => {
 			assert.equal( image.src, mediaItems[ index ].src )
-		})
-		
+		} )
+
 	} )
 
 	it( 'closes full screen gallery when close button is clicked', () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -17,7 +17,7 @@ describe( 'getWikipediaAttrFromUrl', () => {
 		{ url: 'https://en.wikipedia.org/wiki/Cat?action=edit', expected: { lang: 'en', mobile: false, title: 'Cat' } },
 		{ url: 'https://de.wikipedia.org/w/index.php?title=Katze', expected: { lang: 'de', mobile: false, title: 'Katze' } },
 		{ url: 'https://en.m.wikipedia.org/w/index.php?title=Cat&uselang=de', expected: { lang: 'en', mobile: true, title: 'Cat' } },
-		{ url: 'https://es.wikipedia.org/wiki/82.ª_División_Aerotransportada', expected: { lang: 'es', mobile: false, title: '82.ª_División_Aerotransportada'} },
+		{ url: 'https://es.wikipedia.org/wiki/82.ª_División_Aerotransportada', expected: { lang: 'es', mobile: false, title: '82.ª_División_Aerotransportada' } },
 		{ url: 'https://en.wikipedia.org/wiki/Ā', expected: { lang: 'en', mobile: false, title: 'Ā' } },
 		{ url: 'https://it.wikipedia.org/wiki/Željko_Obradović', expected: { lang: 'it', mobile: false, title: 'Željko_Obradović' } },
 		{ url: 'https://en.wikipedia.org/wiki/&Burn', expected: { lang: 'en', mobile: false, title: '&Burn' } },


### PR DESCRIPTION
https://phabricator.wikimedia.org/T261745

# Problem

There are currently a few places where the gallery could be improved:

- it loads very big and heavy images for the fullscreen view
- it's missing the white background for transparent images
- has this issue: [T259854](https://phabricator.wikimedia.org/T259854)
- does not take advantage of the full screen for image layout

# Solution

This ticket is aims to optimize the gallery with respect to some these. Specifically:
        
- use of `iiurlwidth` and `iiurlheight` props to make each fullscreen image as light as possible while still looking good (non-pixelated) on device
  - see the table below for different size comparisons 
- include white background for transparent images
- resolves T259854
- use maximum screen size for image with the image info fixed on top with the same gallery background black color, as a temporary solution.


---

This table shows the difference in sizes, but the final positioning of the image is different after b122a2a977c1c841f4f63a070cc066a95f2375aa

heavier image | lighter image
-- | --
<img width="310" alt="image" src="https://user-images.githubusercontent.com/4752599/93281187-94662300-f799-11ea-9ad8-73250f32a0ba.png">_2550 x 1480_  | <img width="307" alt="image" src="https://user-images.githubusercontent.com/4752599/93281348-e7d87100-f799-11ea-9e21-b43435008133.png">  _375 x 217_
<img width="299" alt="image" src="https://user-images.githubusercontent.com/4752599/93281380-f7f05080-f799-11ea-8e7b-e3dd1174d9a1.png"> _6000 x 4000_ | <img width="289" alt="image" src="https://user-images.githubusercontent.com/4752599/93281510-3d148280-f79a-11ea-947e-ce6200dde58b.png"> _375 x 217_
<img width="298" alt="image" src="https://user-images.githubusercontent.com/4752599/93281553-50275280-f79a-11ea-9d03-65e20dee5988.png"> _2832 x 3730_ | <img width="286" alt="image" src="https://user-images.githubusercontent.com/4752599/93281579-5d444180-f79a-11ea-9aef-a7965a09bd22.png"> _375 x 494_



---

TODO 
- [x] update `requestPageMediaInfo` tests