### PR TITLE
T263544 Shows gallery row when opening up the preview popup if there is enough space

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,14 +35,15 @@ function init( {
 				if ( popup.loading ) {
 					if ( data ) {
 						if ( data.type === 'standard' ) {
+							popup.lang = lang
+							popup.title = title
+
 							popup.show(
 								renderPreview( lang, data, isTouch ),
 								target,
 								pointerPosition
 							)
 
-							popup.lang = lang
-							popup.title = title
 							const expanded = root.querySelector( '.wikipediapreview.expanded.mobile' )
 
 							if ( expanded && popup.expand ) {

--- a/src/index.js
+++ b/src/index.js
@@ -43,12 +43,6 @@ function init( {
 								target,
 								pointerPosition
 							)
-
-							const expanded = root.querySelector( '.wikipediapreview.expanded.mobile' )
-
-							if ( expanded && popup.expand ) {
-								popup.expand()
-							}
 						} else if ( data.type === 'disambiguation' ) {
 							popup.show(
 								renderDisambiguation( isTouch, lang, data.title, data.dir ),


### PR DESCRIPTION
Phab ticket : https://phabricator.wikimedia.org/T263544

Problem
===

Go to the desktop site, https://wikimedia.github.io/wikipedia-preview/demo/articles/hindi.html, hover the second link `हुमांयू`, it shows an empty gallery row

Solution
===

The value should be set before showing the preview