### PR TITLE
Update order of the gallery image info caption or description

### DIFF
--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -53,10 +53,14 @@ const clientWidth = window.innerWidth,
 
 	renderImageInfo = ( mediaInfo, image, lang ) => {
 		const getImageDescription = () => {
-				if ( image.caption ) {
-					return image.caption
-				} else if ( mediaInfo.description ) {
+				// description list order
+				// (1) commons caption - Not found
+				// (2) commons description
+				// (3) media-list caption
+				if ( mediaInfo.description ) {
 					return mediaInfo.description
+				} else if ( image.caption ) {
+					return image.caption
 				} else {
 					return ''
 				}


### PR DESCRIPTION
Phabricator : https://phabricator.wikimedia.org/T262074

Problem
===

The gallery image has caption, description and also caption from the media list api.

Solution
===

The api doesn't return the caption, therefore first choose the media info description then media list caption.