### PR TITLE
T263733 Shows the latest hover link (Race condition edge case)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,8 @@ import { createTouchPopup } from './touchPopup'
 import { renderPreview, renderLoading, renderError, renderDisambiguation, renderOffline } from './preview'
 import { getWikipediaAttrFromUrl, isTouch, getDir, isOnline } from './utils'
 
+let currentPopupId
+
 function init( {
 	root = document,
 	selector = '[data-wikipedia-preview]',
@@ -17,7 +19,8 @@ function init( {
 			createPopup( popupContainer ),
 		events = customEvents( popup ),
 		last = {},
-		showPopup = ( e, refresh = false ) => {
+		showPopup = ( e, refresh = false, popupId = Date.now() ) => {
+			currentPopupId = popupId
 			e.preventDefault()
 			if ( popup.element.style.visibility === 'visible' ) {
 				popup.hide()
@@ -33,6 +36,9 @@ function init( {
 			popup.show( renderLoading( isTouch, lang, dir ), target, pointerPosition )
 
 			requestPagePreview( lang, title, isTouch, data => {
+				if ( popupId !== currentPopupId ) {
+					return
+				}
 				if ( popup.loading ) {
 					popup.loading = false
 					if ( data ) {

--- a/src/index.js
+++ b/src/index.js
@@ -19,13 +19,13 @@ function init( {
 			createPopup( popupContainer ),
 		events = customEvents( popup ),
 		last = {},
-		showPopup = ( e, refresh = false, popupId = Date.now() ) => {
-			currentPopupId = popupId
+		showPopup = ( e, refresh = false ) => {
 			e.preventDefault()
 			if ( popup.element.style.visibility === 'visible' ) {
 				popup.hide()
 			}
-			const { target } = refresh ? last : e,
+			const popupId = currentPopupId = Date.now(),
+				{ target } = refresh ? last : e,
 				title = refresh ? last.title : target.getAttribute( 'data-wp-title' ) || target.textContent,
 				lang = refresh ? last.lang : target.getAttribute( 'data-wp-lang' ) || globalLang,
 				pointerPosition = refresh ? last.pointerPosition : { x: e.clientX, y: e.clientY },


### PR DESCRIPTION
Phab ticket : https://phabricator.wikimedia.org/T263733

Problem 
===

Once hover action is called, the callback event will execute no matter which hovers user have

Solution
===

Remember the user hover id, and do the callback only the hover id and the current hover id is matched

Note
===

We don't clear the request event, that can be reserved as the cache for the next time the user hover it.