### PR TITLE
T260364: Reduce code duplication for preview states

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5,7 +5,7 @@
     "gallery-loading-error-refresh": "Refresh",
     "gallery-loading-still": "Still loading",
     "gallery-unknown-author": "Author unknown",
-    "preview-loading-error": "There was an issue while displaying this preview.",
+    "preview-error-message": "There was an issue while displaying this preview.",
     "read-on-wiki": "Read on Wikipedia",
     "read-more": "Read more on Wikipedia",
     "preview-disambiguation-message": "Title <strong>$1</strong> is related to more than one article on Wikipedia.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -8,7 +8,7 @@
 	"gallery-loading-error-refresh": "Message shown with fullscreen gallery loading error",
 	"gallery-loading-still": "Message shown 5 seconds after a fullscreen gallery image starts loading",
 	"gallery-unknown-author": "Message shown if image author is unknown",
-	"preview-loading-error": "Message shown with a preview loading error",
+	"preview-error-message": "Message shown with a preview loading error",
 	"read-on-wiki": "Message shown in the Call to Action (CTA) of a preview loading error or disambiguation page",
 	"read-more": "The message shown in the footer part of the preview popup that brings user to the wikipedia page to read more about the article",
 	"preview-disambiguation-message": "The message shown for disambiguation pages. Params: \n* $1 - Title of the disambiguation page.",

--- a/src/preview.js
+++ b/src/preview.js
@@ -12,41 +12,34 @@ const getPreviewHeader = ( lang, imageUrl = '' ) =>{
 	`.trim()
 	},
 
-	getPreviewBody = ( lang, title, type, isTouch = false ) => {
-		const getMessage = () => {
-				if ( type === 'disambiguation' ) {
-					return `<span>${msg( lang, `preview-${type}-message`, title )}</span>`
-				}
-				return `<span>${msg( lang, `preview-${type}-message` )}</span>`
-			},
-
-			getCallToAction = () => {
-				if ( type === 'offline' ) {
-					return `<a>${msg( lang, 'preview-offline-cta' )}</a>`
-				}
-				return `<a href="${buildWikipediaUrl( lang, title, isTouch )}" target="_blank">${msg( lang, 'read-on-wiki' )}</a>`
-			}
-
+	getPreviewBody = ( type, message, cta ) => {
 		return `
 			<div class="wikipediapreview-body">
-				<div class="wikipediapreview-body-template-${type}">
+				<div class="wikipediapreview-body-template ${type}">
 					<div class="wikipediapreview-body-template-message">
 						<div class="wikipediapreview-body-template-icon"></div>
-							${getMessage()}
+							${message}
 					</div>
 					<div class="wikipediapreview-body-template-action">
-						${getCallToAction()}
+						${cta}
 					</div>
 				</div>
 			</div>
 	`.trim()
 	},
 
-	renderPreview = ( lang, data, isTouch ) => {
-		const imageUrl = data.imgUrl
+	render = ( lang, isTouch, dir, headerContent, bodyContent ) => {
 		return `
-			<div class="wikipediapreview${isTouch ? ' mobile' : ''}" lang="${lang}" dir="${data.dir}">
-				${getPreviewHeader( lang, imageUrl )}
+			<div class="wikipediapreview ${isTouch ? 'mobile' : ''}" lang="${lang}" dir="${dir}">
+				${headerContent}
+				${bodyContent}
+			</div>
+		`.trim()
+	},
+
+	renderPreview = ( lang, data, isTouch ) => {
+		const imageUrl = data.imgUrl,
+			bodyContent = `
 				<div class="wikipediapreview-body">
 					${data.extractHtml}
 					<div class="wikipediapreview-gallery">
@@ -56,58 +49,52 @@ const getPreviewHeader = ( lang, imageUrl = '' ) =>{
 					<span class="wikipediapreview-footer-cta wikipediapreview-footer-cta-readmore">${msg( lang, 'continue-reading' )}</span>
 					<a href="${buildWikipediaUrl( lang, data.title, isTouch )}" class="wikipediapreview-footer-cta wikipediapreview-footer-cta-readonwiki" target="_blank">${msg( lang, 'read-more' )}</a>
 				</div>
-			</div>
-	`.trim()
+			`.trim()
+
+		return render( lang, isTouch, data.dir, getPreviewHeader( lang, imageUrl ), bodyContent )
 	},
 
 	renderLoading = ( isTouch, lang, dir ) => {
-		return `
-			<div class="wikipediapreview${isTouch ? ' mobile' : ''}" lang="${lang}" dir="${dir}">
-					${getPreviewHeader( lang )}
-					<div class="wikipediapreview-loading">
-						<div class="wikipediapreview-body">
-							<div class="wikipediapreview-loading-body-line larger"></div>
-							<div class="wikipediapreview-loading-body-line medium"></div>
-							<div class="wikipediapreview-loading-body-line larger"></div>
-							<div class="wikipediapreview-loading-body-line medium"></div>
-							<div class="wikipediapreview-loading-body-line smaller"></div>
-							<div class="wikipediapreview-loading-body-line larger"></div>
-							<div class="wikipediapreview-loading-body-line medium"></div>
-							<div class="wikipediapreview-loading-body-line larger"></div>
-							<div class="wikipediapreview-loading-body-line medium"></div>
-							<div class="wikipediapreview-loading-body-line smaller"></div>
-						</div>
-					</div>
-					<div class="wikipediapreview-loading-footer"></div>
-			</div>
-  `.trim()
+		const bodyContent = `
+      <div class="wikipediapreview-loading">
+        <div class="wikipediapreview-body">
+          <div class="wikipediapreview-loading-body-line larger"></div>
+          <div class="wikipediapreview-loading-body-line medium"></div>
+          <div class="wikipediapreview-loading-body-line larger"></div>
+          <div class="wikipediapreview-loading-body-line medium"></div>
+          <div class="wikipediapreview-loading-body-line smaller"></div>
+          <div class="wikipediapreview-loading-body-line larger"></div>
+          <div class="wikipediapreview-loading-body-line medium"></div>
+          <div class="wikipediapreview-loading-body-line larger"></div>
+          <div class="wikipediapreview-loading-body-line medium"></div>
+          <div class="wikipediapreview-loading-body-line smaller"></div>
+        </div>
+      </div>
+      <div class="wikipediapreview-loading-footer"></div>
+    `.trim()
+
+		return render( lang, isTouch, dir, getPreviewHeader( lang ), bodyContent )
 	},
 
 	renderError = ( isTouch, lang, title, dir ) => {
-		return `
-			<div class="wikipediapreview expanded ${isTouch ? 'mobile' : ''}" lang="${lang}" dir="${dir}">
-					${getPreviewHeader( lang )}
-					${getPreviewBody( lang, title, 'error', isTouch )}
-			</div>
-	`.trim()
+		const message = `<span>${msg( lang, 'preview-error-message' )}</span>`,
+			cta = `<a href="${buildWikipediaUrl( lang, title, isTouch )}" target="_blank">${msg( lang, 'read-on-wiki' )}</a>`
+
+		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'error', message, cta ) )
 	},
 
 	renderDisambiguation = ( isTouch, lang, title, dir ) => {
-		return `
-			<div class="wikipediapreview expanded ${isTouch ? 'mobile' : ''}" lang="${lang}" dir="${dir}">
-					${getPreviewHeader( lang )}
-					${getPreviewBody( lang, title, 'disambiguation', isTouch )}
-			</div>
-	`.trim()
+		const message = `<span>${msg( lang, 'preview-disambiguation-message', title )}</span>`,
+			cta = `<a href="${buildWikipediaUrl( lang, title, isTouch )}" target="_blank">${msg( lang, 'read-on-wiki' )}</a>`
+
+		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'disambiguation', message, cta ) )
 	},
 
 	renderOffline = ( isTouch, lang, dir ) => {
-		return `
-			<div class="wikipediapreview expanded ${isTouch ? 'mobile' : ''}" lang="${lang}" dir="${dir}">
-					${getPreviewHeader( lang )}
-					${getPreviewBody( lang, false, 'offline', isTouch )}
-			</div>
-	`.trim()
+		const message = `<span>${msg( lang, 'preview-offline-message' )}</span>`,
+			cta = `<a>${msg( lang, 'preview-offline-cta' )}</a>`
+
+		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'offline', message, cta ) )
 	}
 
 export { renderPreview, renderLoading, renderError, renderDisambiguation, renderOffline }

--- a/src/preview.js
+++ b/src/preview.js
@@ -14,15 +14,13 @@ const getPreviewHeader = ( lang, imageUrl = '' ) =>{
 
 	getPreviewBody = ( type, message, cta ) => {
 		return `
-			<div class="wikipediapreview-body">
-				<div class="wikipediapreview-body-template ${type}">
-					<div class="wikipediapreview-body-template-message">
-						<div class="wikipediapreview-body-template-icon"></div>
-							${message}
-					</div>
-					<div class="wikipediapreview-body-template-action">
-						${cta}
-					</div>
+			<div class="wikipediapreview-body wikipediapreview-body-${type}">
+				<div class="wikipediapreview-body-message">
+					<div class="wikipediapreview-body-icon"></div>
+						${message}
+				</div>
+				<div class="wikipediapreview-body-action">
+					${cta}
 				</div>
 			</div>
 	`.trim()
@@ -80,21 +78,21 @@ const getPreviewHeader = ( lang, imageUrl = '' ) =>{
 		const message = `<span>${msg( lang, 'preview-error-message' )}</span>`,
 			cta = `<a href="${buildWikipediaUrl( lang, title, isTouch )}" target="_blank">${msg( lang, 'read-on-wiki' )}</a>`
 
-		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'wikipediapreview-body-error', message, cta ) )
+		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'error', message, cta ) )
 	},
 
 	renderDisambiguation = ( isTouch, lang, title, dir ) => {
 		const message = `<span>${msg( lang, 'preview-disambiguation-message', title )}</span>`,
 			cta = `<a href="${buildWikipediaUrl( lang, title, isTouch )}" target="_blank">${msg( lang, 'read-on-wiki' )}</a>`
 
-		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'wikipediapreview-body-disambiguation', message, cta ) )
+		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'disambiguation', message, cta ) )
 	},
 
 	renderOffline = ( isTouch, lang, dir ) => {
 		const message = `<span>${msg( lang, 'preview-offline-message' )}</span>`,
 			cta = `<a>${msg( lang, 'preview-offline-cta' )}</a>`
 
-		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'wikipediapreview-body-offline', message, cta ) )
+		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'offline', message, cta ) )
 	}
 
 export { renderPreview, renderLoading, renderError, renderDisambiguation, renderOffline }

--- a/src/preview.js
+++ b/src/preview.js
@@ -54,21 +54,19 @@ const getPreviewHeader = ( lang, imageUrl = '' ) =>{
 
 	renderLoading = ( isTouch, lang, dir ) => {
 		const bodyContent = `
-      <div class="wikipediapreview-loading">
-        <div class="wikipediapreview-body">
-          <div class="wikipediapreview-loading-body-line larger"></div>
-          <div class="wikipediapreview-loading-body-line medium"></div>
-          <div class="wikipediapreview-loading-body-line larger"></div>
-          <div class="wikipediapreview-loading-body-line medium"></div>
-          <div class="wikipediapreview-loading-body-line smaller"></div>
-          <div class="wikipediapreview-loading-body-line larger"></div>
-          <div class="wikipediapreview-loading-body-line medium"></div>
-          <div class="wikipediapreview-loading-body-line larger"></div>
-          <div class="wikipediapreview-loading-body-line medium"></div>
-          <div class="wikipediapreview-loading-body-line smaller"></div>
-        </div>
-      </div>
-      <div class="wikipediapreview-loading-footer"></div>
+      <div class="wikipediapreview-body wikipediapreview-body-loading">
+				<div class="wikipediapreview-body-loading-line larger"></div>
+				<div class="wikipediapreview-body-loading-line medium"></div>
+				<div class="wikipediapreview-body-loading-line larger"></div>
+				<div class="wikipediapreview-body-loading-line medium"></div>
+				<div class="wikipediapreview-body-loading-line smaller"></div>
+				<div class="wikipediapreview-body-loading-line larger"></div>
+				<div class="wikipediapreview-body-loading-line medium"></div>
+				<div class="wikipediapreview-body-loading-line larger"></div>
+				<div class="wikipediapreview-body-loading-line medium"></div>
+				<div class="wikipediapreview-body-loading-line smaller"></div>
+			</div>
+			<div class="wikipediapreview-footer-loading"></div>
     `.trim()
 
 		return render( lang, isTouch, dir, getPreviewHeader( lang ), bodyContent )

--- a/src/preview.js
+++ b/src/preview.js
@@ -80,21 +80,21 @@ const getPreviewHeader = ( lang, imageUrl = '' ) =>{
 		const message = `<span>${msg( lang, 'preview-error-message' )}</span>`,
 			cta = `<a href="${buildWikipediaUrl( lang, title, isTouch )}" target="_blank">${msg( lang, 'read-on-wiki' )}</a>`
 
-		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'error', message, cta ) )
+		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'wikipediapreview-body-error', message, cta ) )
 	},
 
 	renderDisambiguation = ( isTouch, lang, title, dir ) => {
 		const message = `<span>${msg( lang, 'preview-disambiguation-message', title )}</span>`,
 			cta = `<a href="${buildWikipediaUrl( lang, title, isTouch )}" target="_blank">${msg( lang, 'read-on-wiki' )}</a>`
 
-		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'disambiguation', message, cta ) )
+		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'wikipediapreview-body-disambiguation', message, cta ) )
 	},
 
 	renderOffline = ( isTouch, lang, dir ) => {
 		const message = `<span>${msg( lang, 'preview-offline-message' )}</span>`,
 			cta = `<a>${msg( lang, 'preview-offline-cta' )}</a>`
 
-		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'offline', message, cta ) )
+		return render( lang, isTouch, dir, getPreviewHeader( lang ), getPreviewBody( 'wikipediapreview-body-offline', message, cta ) )
 	}
 
 export { renderPreview, renderLoading, renderError, renderDisambiguation, renderOffline }

--- a/src/preview.js
+++ b/src/preview.js
@@ -12,6 +12,36 @@ const getPreviewHeader = ( lang, imageUrl = '' ) =>{
 	`.trim()
 	},
 
+	getPreviewBody = ( lang, title, type, isTouch = false ) => {
+		const getMessage = () => {
+				if ( type === 'disambiguation' ) {
+					return `<span>${msg( lang, `preview-${type}-message`, title )}</span>`
+				}
+				return `<span>${msg( lang, `preview-${type}-message` )}</span>`
+			},
+
+			getCallToAction = () => {
+				if ( type === 'offline' ) {
+					return `<a>${msg( lang, 'preview-offline-cta' )}</a>`
+				}
+				return `<a href="${buildWikipediaUrl( lang, title, isTouch )}" target="_blank">${msg( lang, 'read-on-wiki' )}</a>`
+			}
+
+		return `
+			<div class="wikipediapreview-body">
+				<div class="wikipediapreview-body-template-${type}">
+					<div class="wikipediapreview-body-template-message">
+						<div class="wikipediapreview-body-template-icon"></div>
+							${getMessage()}
+					</div>
+					<div class="wikipediapreview-body-template-action">
+						${getCallToAction()}
+					</div>
+				</div>
+			</div>
+	`.trim()
+	},
+
 	renderPreview = ( lang, data, isTouch ) => {
 		const imageUrl = data.imgUrl
 		return `
@@ -57,17 +87,7 @@ const getPreviewHeader = ( lang, imageUrl = '' ) =>{
 		return `
 			<div class="wikipediapreview expanded ${isTouch ? 'mobile' : ''}" lang="${lang}" dir="${dir}">
 					${getPreviewHeader( lang )}
-					<div class="wikipediapreview-body">
-						<div class="wikipediapreview-error-body">
-							<div class="wikipediapreview-error-body-message">
-								<div class="wikipediapreview-error-body-icon"></div>
-								${msg( lang, 'preview-loading-error' )}
-							</div>
-							<div class="wikipediapreview-error-body-readon">
-								<a href="${buildWikipediaUrl( lang, title, isTouch )}" target="_blank">${msg( lang, 'read-on-wiki' )}</a>
-							</div>
-						</div>
-					</div>
+					${getPreviewBody( lang, title, 'error', isTouch )}
 			</div>
 	`.trim()
 	},
@@ -76,17 +96,7 @@ const getPreviewHeader = ( lang, imageUrl = '' ) =>{
 		return `
 			<div class="wikipediapreview expanded ${isTouch ? 'mobile' : ''}" lang="${lang}" dir="${dir}">
 					${getPreviewHeader( lang )}
-					<div class="wikipediapreview-body">
-						<div class="wikipediapreview-disambiguation-body">
-							<div class="wikipediapreview-disambiguation-body-message">
-								<div class="wikipediapreview-disambiguation-body-icon"></div>
-								<span>${msg( lang, 'preview-disambiguation-message', title )}</span>
-							</div>
-							<div class="wikipediapreview-disambiguation-body-readon">
-								<a href="${buildWikipediaUrl( lang, title, isTouch )}" target="_blank">${msg( lang, 'read-on-wiki' )}</a>
-							</div>
-						</div>
-					</div>
+					${getPreviewBody( lang, title, 'disambiguation', isTouch )}
 			</div>
 	`.trim()
 	},
@@ -95,17 +105,7 @@ const getPreviewHeader = ( lang, imageUrl = '' ) =>{
 		return `
 			<div class="wikipediapreview expanded ${isTouch ? 'mobile' : ''}" lang="${lang}" dir="${dir}">
 					${getPreviewHeader( lang )}
-					<div class="wikipediapreview-body">
-						<div class="wikipediapreview-offline-body">
-							<div class="wikipediapreview-offline-body-message">
-								<div class="wikipediapreview-offline-body-icon"></div>
-								<span>${msg( lang, 'preview-offline-message' )}</span>
-							</div>
-							<div class="wikipediapreview-offline-body-retry">
-								<a>${msg( lang, 'preview-offline-cta' )}</a>
-							</div>
-						</div>
-					</div>
+					${getPreviewBody( lang, false, 'offline', isTouch )}
 			</div>
 	`.trim()
 	}

--- a/style/preview.less
+++ b/style/preview.less
@@ -1,3 +1,40 @@
+.wikipediapreview-body-template {
+	height: 240px;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+
+	&-message {
+		display: flex;
+		margin-left: 23px;
+		margin-right: 23px;
+		font-size: 16px;
+		line-height: 1.4;
+		color: #000;
+	}
+
+	&-icon {
+		content: inline-svg( '../images/error-preview.svg' );
+		display: absolute;
+		vertical-align: middle;
+		margin-right: 12px;
+		width: 20px;
+		height: 20px;
+	}
+
+	&-action {
+		margin-left: 55px;
+		margin-top: 12px;
+		font-size: 16px;
+		font-weight: bold;
+		cursor: pointer;
+
+		a {
+			color: #36c;
+		}
+	}
+}
+
 .wikipediapreview {
 	display: flex;
 	flex-direction: column;
@@ -92,6 +129,35 @@
 			line-height: 1.6;
 			font-size: 18px;
 			padding: 10px 20px;
+		}
+
+		&-template-error {
+			&:extend( .wikipediapreview-body-template );
+		}
+
+		&-template-disambiguation {
+			&:extend( .wikipediapreview-body-template );
+
+			.wikipediapreview-body-template-icon {
+				content: inline-svg( '../images/articles.svg' );
+			}
+		}
+
+		&-template-offline {
+			&:extend( .wikipediapreview-body-template );
+
+			.wikipediapreview-body-template-message {
+				margin-left: 16px;
+				margin-right: 16px;
+			}
+
+			.wikipediapreview-body-template-icon {
+				content: inline-svg( '../images/offline-icon.svg' );
+			}
+
+			.wikipediapreview-body-template-action {
+				margin: 12px 49px;
+			}
 		}
 	}
 
@@ -196,121 +262,6 @@
 		&-footer {
 			height: 30px;
 			background-color: #eaecf0;
-		}
-	}
-
-	&-error {
-		&-body {
-			height: 240px;
-			display: flex;
-			flex-direction: column;
-			justify-content: center;
-
-			&-message {
-				display: flex;
-				margin-left: 23px;
-				margin-right: 23px;
-				font-size: 16px;
-				line-height: 1.4;
-				color: #000;
-			}
-
-			&-icon {
-				content: inline-svg( '../images/error-preview.svg' );
-				display: absolute;
-				vertical-align: middle;
-				margin-right: 12px;
-				width: 20px;
-				height: 20px;
-			}
-
-			&-readon {
-				margin-left: 55px;
-				margin-top: 12px;
-				font-size: 16px;
-				font-weight: bold;
-				cursor: pointer;
-
-				a {
-					color: #36c;
-				}
-			}
-		}
-	}
-
-	&-disambiguation {
-		&-body {
-			height: 240px;
-			display: flex;
-			flex-direction: column;
-			justify-content: center;
-
-			&-message {
-				display: flex;
-				margin-left: 23px;
-				margin-right: 23px;
-				font-size: 16px;
-				line-height: 1.4;
-				color: #000;
-			}
-
-			&-icon {
-				content: inline-svg( '../images/articles.svg' );
-				display: absolute;
-				vertical-align: middle;
-				margin-right: 12px;
-				width: 20px;
-				height: 20px;
-			}
-
-			&-readon {
-				margin: 12px 55px;
-				font-size: 16px;
-				font-weight: bold;
-				cursor: pointer;
-
-				a {
-					color: #36c;
-				}
-			}
-		}
-	}
-
-	&-offline {
-		&-body {
-			height: 240px;
-			display: flex;
-			flex-direction: column;
-			justify-content: center;
-
-			&-message {
-				display: flex;
-				margin-left: 16px;
-				margin-right: 16px;
-				font-size: 16px;
-				line-height: 1.4;
-				color: #000;
-			}
-
-			&-icon {
-				content: inline-svg( '../images/offline-icon.svg' );
-				display: absolute;
-				vertical-align: middle;
-				margin-right: 12px;
-				width: 20px;
-				height: 20px;
-			}
-
-			&-retry {
-				margin: 12px 49px;
-				font-size: 16px;
-				font-weight: bold;
-				cursor: pointer;
-
-				a {
-					color: #36c;
-				}
-			}
 		}
 	}
 

--- a/style/preview.less
+++ b/style/preview.less
@@ -155,41 +155,16 @@
 				margin: 12px 49px;
 			}
 		}
-	}
 
-	&-footer {
-		position: relative;
+		&.wikipediapreview-body-loading {
+			&:extend( .wikipediapreview-body-non-regular );
+			padding: 10px 20px;
 
-		&-cta {
-			width: 100%;
-			height: 50px;
-			text-decoration: none;
-			text-align: center;
-			padding: 16px;
-			font-size: 18px;
-			color: #36c;
-
-			&-readmore {
-				cursor: pointer;
-				display: block;
+			&:after {
+				content: none;
 			}
 
-			&-readonwiki {
-				display: none;
-			}
-		}
-	}
-
-	&-loading {
-		padding: 10px 20px;
-
-		&-body {
-			height: 100%;
-			margin-top: 25px;
-			padding-left: 13px;
-			padding-right: 13px;
-
-			&-line {
+			.wikipediapreview-body-loading-line {
 				height: 10px;
 				margin-top: 12px;
 				border-radius: 1px;
@@ -200,15 +175,15 @@
 				animation: animate-load 2s ease infinite;
 			}
 
-			&-line.larger {
+			.wikipediapreview-body-loading-line.larger {
 				width: 100%;
 			}
 
-			&-line.medium {
+			.wikipediapreview-body-loading-line.medium {
 				width: 80%;
 			}
 
-			&-line.smaller {
+			.wikipediapreview-body-loading-line.smaller {
 				width: 60%;
 			}
 
@@ -254,8 +229,31 @@
 				}
 			}
 		}
+	}
 
-		&-footer {
+	&-footer {
+		position: relative;
+
+		&-cta {
+			width: 100%;
+			height: 50px;
+			text-decoration: none;
+			text-align: center;
+			padding: 16px;
+			font-size: 18px;
+			color: #36c;
+
+			&-readmore {
+				cursor: pointer;
+				display: block;
+			}
+
+			&-readonwiki {
+				display: none;
+			}
+		}
+
+		&-loading {
 			height: 30px;
 			background-color: #eaecf0;
 		}

--- a/style/preview.less
+++ b/style/preview.less
@@ -129,19 +129,19 @@
 				}
 			}
 
-			&.error {
+			&.wikipediapreview-body-error {
 				.wikipediapreview-body-template-icon {
 					content: inline-svg( '../images/error-preview.svg' );
 				}
 			}
 
-			&.disambiguation {
+			&.wikipediapreview-body-disambiguation {
 				.wikipediapreview-body-template-icon {
 					content: inline-svg( '../images/articles.svg' );
 				}
 			}
 
-			&.offline {
+			&.wikipediapreview-body-offline {
 				.wikipediapreview-body-template-message {
 					margin-left: 16px;
 					margin-right: 16px;

--- a/style/preview.less
+++ b/style/preview.less
@@ -1,40 +1,3 @@
-.wikipediapreview-body-template {
-	height: 240px;
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-
-	&-message {
-		display: flex;
-		margin-left: 23px;
-		margin-right: 23px;
-		font-size: 16px;
-		line-height: 1.4;
-		color: #000;
-	}
-
-	&-icon {
-		content: inline-svg( '../images/error-preview.svg' );
-		display: absolute;
-		vertical-align: middle;
-		margin-right: 12px;
-		width: 20px;
-		height: 20px;
-	}
-
-	&-action {
-		margin-left: 55px;
-		margin-top: 12px;
-		font-size: 16px;
-		font-weight: bold;
-		cursor: pointer;
-
-		a {
-			color: #36c;
-		}
-	}
-}
-
 .wikipediapreview {
 	display: flex;
 	flex-direction: column;
@@ -131,32 +94,66 @@
 			padding: 10px 20px;
 		}
 
-		&-template-error {
-			&:extend( .wikipediapreview-body-template );
-		}
+		&-template {
+			height: 240px;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
 
-		&-template-disambiguation {
-			&:extend( .wikipediapreview-body-template );
-
-			.wikipediapreview-body-template-icon {
-				content: inline-svg( '../images/articles.svg' );
-			}
-		}
-
-		&-template-offline {
-			&:extend( .wikipediapreview-body-template );
-
-			.wikipediapreview-body-template-message {
-				margin-left: 16px;
-				margin-right: 16px;
+			&-message {
+				display: flex;
+				margin-left: 23px;
+				margin-right: 23px;
+				font-size: 16px;
+				line-height: 1.4;
+				color: #000;
 			}
 
-			.wikipediapreview-body-template-icon {
-				content: inline-svg( '../images/offline-icon.svg' );
+			&-icon {
+				display: absolute;
+				vertical-align: middle;
+				margin-right: 12px;
+				width: 20px;
+				height: 20px;
 			}
 
-			.wikipediapreview-body-template-action {
-				margin: 12px 49px;
+			&-action {
+				margin-left: 55px;
+				margin-top: 12px;
+				font-size: 16px;
+				font-weight: bold;
+				cursor: pointer;
+
+				a {
+					color: #36c;
+				}
+			}
+
+			&.error {
+				.wikipediapreview-body-template-icon {
+					content: inline-svg( '../images/error-preview.svg' );
+				}
+			}
+
+			&.disambiguation {
+				.wikipediapreview-body-template-icon {
+					content: inline-svg( '../images/articles.svg' );
+				}
+			}
+
+			&.offline {
+				.wikipediapreview-body-template-message {
+					margin-left: 16px;
+					margin-right: 16px;
+				}
+
+				.wikipediapreview-body-template-icon {
+					content: inline-svg( '../images/offline-icon.svg' );
+				}
+
+				.wikipediapreview-body-template-action {
+					margin: 12px 49px;
+				}
 			}
 		}
 	}

--- a/style/preview.less
+++ b/style/preview.less
@@ -94,66 +94,65 @@
 			padding: 10px 20px;
 		}
 
-		&-template {
-			height: 240px;
+		&-message {
 			display: flex;
-			flex-direction: column;
-			justify-content: center;
+			margin-left: 23px;
+			margin-right: 23px;
+			font-size: 16px;
+			line-height: 1.4;
+			color: #000;
+		}
 
-			&-message {
-				display: flex;
-				margin-left: 23px;
-				margin-right: 23px;
-				font-size: 16px;
-				line-height: 1.4;
-				color: #000;
+		&-icon {
+			display: absolute;
+			vertical-align: middle;
+			margin-right: 12px;
+			width: 20px;
+			height: 20px;
+		}
+
+		&-action {
+			margin-left: 55px;
+			margin-top: 12px;
+			font-size: 16px;
+			font-weight: bold;
+			cursor: pointer;
+
+			a {
+				color: #36c;
+			}
+		}
+
+		&.wikipediapreview-body-error {
+			&:extend( .wikipediapreview-body-non-regular );
+
+			.wikipediapreview-body-icon {
+				content: inline-svg( '../images/error-preview.svg' );
+			}
+		}
+
+		&.wikipediapreview-body-disambiguation {
+			&:extend( .wikipediapreview-body-non-regular );
+
+			.wikipediapreview-body-icon {
+				content: inline-svg( '../images/articles.svg' );
+			}
+		}
+
+		&.wikipediapreview-body-offline {
+			&:extend( .wikipediapreview-body-non-regular );
+
+			.wikipediapreview-body-message {
+				margin-left: 16px;
+				margin-right: 16px;
 			}
 
-			&-icon {
-				display: absolute;
-				vertical-align: middle;
-				margin-right: 12px;
-				width: 20px;
-				height: 20px;
+			.wikipediapreview-body-icon {
+				content: inline-svg( '../images/offline-icon.svg' );
 			}
 
-			&-action {
-				margin-left: 55px;
-				margin-top: 12px;
-				font-size: 16px;
-				font-weight: bold;
-				cursor: pointer;
-
-				a {
-					color: #36c;
-				}
-			}
-
-			&.wikipediapreview-body-error {
-				.wikipediapreview-body-template-icon {
-					content: inline-svg( '../images/error-preview.svg' );
-				}
-			}
-
-			&.wikipediapreview-body-disambiguation {
-				.wikipediapreview-body-template-icon {
-					content: inline-svg( '../images/articles.svg' );
-				}
-			}
-
-			&.wikipediapreview-body-offline {
-				.wikipediapreview-body-template-message {
-					margin-left: 16px;
-					margin-right: 16px;
-				}
-
-				.wikipediapreview-body-template-icon {
-					content: inline-svg( '../images/offline-icon.svg' );
-				}
-
-				.wikipediapreview-body-template-action {
-					margin: 12px 49px;
-				}
+			.wikipediapreview-body-action {
+				margin: 12px 49px;
 			}
 		}
 	}
@@ -308,6 +307,16 @@
 			margin-left: 0;
 		}
 
+		.wikipediapreview-body-icon {
+			margin-right: 0;
+			margin-left: 12px;
+		}
+
+		.wikipediapreview-body-action {
+			margin-left: 0;
+			margin-right: 55px;
+		}
+
 		.wikipediapreview-footer {
 			&-cc {
 				left: 30px;
@@ -319,34 +328,12 @@
 				right: unset;
 			}
 		}
-
-		.wikipediapreview-error-body {
-			&-message {
-				margin-left: 0;
-				margin-right: 23px;
-			}
-
-			&-icon {
-				margin-right: 0;
-				margin-left: 12px;
-			}
-
-			&-readon {
-				margin-left: 0;
-				margin-right: 55px;
-			}
-		}
-
-		.wikipediapreview-offline-body-icon {
-			margin-right: 0;
-			margin-left: 12px;
-		}
-
-		.wikipediapreview-disambiguation-body {
-			&-icon {
-				margin-right: 0;
-				margin-left: 12px;
-			}
-		}
 	}
+}
+
+.wikipediapreview-body-non-regular {
+	height: 240px;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
 }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T260364

# Problem
> The file preview.js contains the rendering code for the 5 states of the preview: standard, loading, error, disambiguation, offline. They have almost identical chrome and layout but the markup and style are duplicated.

# Solution

Refactoring with https://github.com/wikimedia/wikipedia-preview/commit/809c6d4f55eb6325e2ba6ab8437a67faf4f26281:
* Net difference in preview.js is even (_33 additions & 33 deletions_) but it should be easier to maintain this way
* Reduction of code lines come through preview.less. I opted to retain whatever specific CSS for each state as they were.
* The [storybook](https://github.com/storybookjs/storybook) was really useful to develop and test different states. Also tested on device.

