### PR TITLE
T263009: gallery sliding bug

### DIFF
--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -251,7 +251,7 @@ const clientWidth = window.innerWidth,
 			) {
 				renderNext( diff > 0 ? 1 : -1 )
 			} else {
-				container.style[ marginLR ] = temp.originalMarginLeft + 'px'
+				container.style[ marginLR ] = -clientWidth * current + 'px'
 			}
 		} )
 	},


### PR DESCRIPTION
https://phabricator.wikimedia.org/T263009

# Problem

When tapping the gallery next/previous buttons rapidly, sometimes the rendered image displays in a buggy in-transition state. The issue comes from a slight conflict between the touch events (`applyGestureEvent`) and the next/previous click events (`renderNext`): if a `touchstart` is triggered when the image is in-transition, the `temp.originalMarginLeft` value gets set to a in-transition value and therefore the image can "land" on the in-transition state.

# Solution

Setting the final margin with `clientWidth` and `current` (like we do in `renderNext`) is more reliable because these won't reflect an in-transition state. 
