### PR TITLE
T262373: add gallery focus mode

### DIFF
--- a/images/caption-cue-expanded.svg
+++ b/images/caption-cue-expanded.svg
@@ -1,0 +1,1 @@
+<svg width="37" height="9" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M.698 1.923L18.5 7l17.453-5.077" stroke="#fff" stroke-width="2"/><ellipse cx="35.953" cy="1.923" rx="1.047" ry=".923" fill="#fff"/><ellipse cx=".698" cy="1.923" rx=".698" ry=".923" fill="#fff"/></svg>

--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -169,6 +169,20 @@ const clientWidth = window.innerWidth,
 		}
 	},
 
+	handleCaptionExpansion = ( item, forceClose = false ) => {
+		const captionText = item.querySelector( `.${prefixClassname}-item-caption-text` ),
+			expandCue = item.querySelector( `.${prefixClassname}-item-caption-expand-cue` ),
+			expanded = item.querySelector( '.expanded' )
+
+		if ( expandCue && expanded || forceClose && expandCue ) {
+			expandCue.classList.remove( 'expanded' )
+			captionText.style.maxHeight = '80px'
+		} else if ( expandCue ) {
+			expandCue.classList.add( 'expanded' )
+			captionText.style.maxHeight = '241px'
+		}
+	},
+
 	showImageAndInfo = ( index, refreshImage = false ) => {
 		const slider = parentContainer.querySelector( `.${prefixClassname}` ),
 			items = slider.querySelectorAll( `.${prefixClassname}-item` ),
@@ -198,20 +212,10 @@ const clientWidth = window.innerWidth,
 							renderImageInfo( mediaInfo, gallery[ index ], lang
 							) )
 
-						const insertedCaption = item.querySelector( `.${prefixClassname}-item-caption` ),
-							insertedCaptionText = item.querySelector( `.${prefixClassname}-item-caption-text` )
+						const insertedCaption = item.querySelector( `.${prefixClassname}-item-caption` )
 
 						insertedCaption.addEventListener( 'click', () => {
-							const expandCue = item.querySelector( `.${prefixClassname}-item-caption-expand-cue` ),
-								expanded = insertedCaption.querySelector( '.expanded' )
-
-							if ( expandCue && expanded ) {
-								expandCue.classList.remove( 'expanded' )
-								insertedCaptionText.style.maxHeight = '80px'
-							} else if ( expandCue ) {
-								expandCue.classList.add( 'expanded' )
-								insertedCaptionText.style.maxHeight = '241px'
-							}
+							handleCaptionExpansion( item )
 						} )
 					}
 				} )
@@ -227,6 +231,7 @@ const clientWidth = window.innerWidth,
 			item = items[ next ]
 
 		if ( item ) {
+			handleCaptionExpansion( items[ current ], true )
 			current += offset
 			nextButton.style.opacity = current === items.length - 1 ? '0.5' : '1'
 			previousButton.style.opacity = current === 0 ? '0.5' : '1'

--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -7,7 +7,8 @@ let current = 0,
 	dir = '',
 	lang,
 	gallery,
-	parentContainer
+	parentContainer,
+	focusMode = false
 
 const clientWidth = window.innerWidth,
 	prefixClassname = 'wp-gallery-fullscreen-slider',
@@ -212,11 +213,17 @@ const clientWidth = window.innerWidth,
 							renderImageInfo( mediaInfo, gallery[ index ], lang
 							) )
 
-						const insertedCaption = item.querySelector( `.${prefixClassname}-item-caption` )
+						const insertedCaption = item.querySelector( `.${prefixClassname}-item-caption` ),
+							insertedAttribution = item.querySelector( `.${prefixClassname}-item-attribution` )
 
 						insertedCaption.addEventListener( 'click', () => {
 							handleCaptionExpansion( item )
 						} )
+
+						if ( focusMode ) {
+							insertedCaption.style.visibility = 'hidden'
+							insertedAttribution.style.visibility = 'hidden'
+						}
 					}
 				} )
 		}
@@ -308,6 +315,30 @@ const clientWidth = window.innerWidth,
 		} )
 	},
 
+	toggleFocusMode = () => {
+		const toggleElements = [
+			'.wp-gallery-fullscreen-close',
+			'.previous',
+			'.next',
+			'.wp-gallery-fullscreen-slider-item-caption',
+			'.wp-gallery-fullscreen-slider-item-attribution'
+		]
+
+		focusMode = !focusMode
+		toggleElements.forEach( elementName => {
+			Array.prototype.forEach.call(
+				parentContainer.querySelectorAll( elementName ),
+				element => {
+					if ( element.style.visibility === 'hidden' ) {
+						element.style.visibility = 'visible'
+					} else {
+						element.style.visibility = 'hidden'
+					}
+				}
+			)
+		} )
+	},
+
 	onShowFn = () => {
 		const sliderContainer = parentContainer.querySelector( `.${prefixClassname}` ),
 			items = sliderContainer.querySelectorAll( `.${prefixClassname}-item` ),
@@ -316,6 +347,13 @@ const clientWidth = window.innerWidth,
 
 		renderNext( 0 )
 		applyGestureEvent()
+
+		sliderContainer.addEventListener( 'click', ( e ) => {
+			if ( e.target.className === 'wp-gallery-fullscreen-slider-item' ||
+					e.target.tagName === 'IMG' ) {
+				toggleFocusMode()
+			}
+		} )
 
 		if ( items.length === 1 ) {
 			previousButton.style.visibility = 'hidden'

--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -80,12 +80,22 @@ const clientWidth = window.innerWidth,
 
 			author = mediaInfo.author ? mediaInfo.author : msg( lang, 'gallery-unknown-author' ),
 			link = mediaInfo.filePage,
-			description = getImageDescription()
+			description = getImageDescription(),
+
+			isCaptionExpandable = () => {
+				if ( clientWidth < 400 && description.length > 128 ) {
+					return true
+				} else if ( clientWidth > 400 && description.length > 142 ) {
+					return true
+				} else {
+					return false
+				}
+			}
 
 		// @todo consider a wrapper container for all the image info?
 		return `
 			<div class="${prefixClassname}-item-caption">
-				${description.length > 95 ? `<div class="${prefixClassname}-item-caption-expand-cue"></div>` : ''}
+				${isCaptionExpandable() ? `<div class="${prefixClassname}-item-caption-expand-cue"></div>` : ''}
 				<div class="${prefixClassname}-item-caption-text">${description}</div>
 			</div>
 			<div class="${prefixClassname}-item-attribution">

--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -221,8 +221,8 @@ const clientWidth = window.innerWidth,
 						} )
 
 						if ( focusMode ) {
-							insertedCaption.style.visibility = 'hidden'
-							insertedAttribution.style.visibility = 'hidden'
+							insertedCaption.classList.add( `${prefixClassname}-focus-mode` )
+							insertedAttribution.classList.add( `${prefixClassname}-focus-mode` )
 						}
 					}
 				} )
@@ -320,8 +320,8 @@ const clientWidth = window.innerWidth,
 			'.wp-gallery-fullscreen-close',
 			'.previous',
 			'.next',
-			'.wp-gallery-fullscreen-slider-item-caption',
-			'.wp-gallery-fullscreen-slider-item-attribution'
+			`.${prefixClassname}-item-caption`,
+			`.${prefixClassname}-item-attribution`
 		]
 
 		focusMode = !focusMode
@@ -329,11 +329,7 @@ const clientWidth = window.innerWidth,
 			Array.prototype.forEach.call(
 				parentContainer.querySelectorAll( elementName ),
 				element => {
-					if ( element.style.visibility === 'hidden' ) {
-						element.style.visibility = 'visible'
-					} else {
-						element.style.visibility = 'hidden'
-					}
+					element.classList.toggle( `${prefixClassname}-focus-mode` )
 				}
 			)
 		} )
@@ -349,7 +345,7 @@ const clientWidth = window.innerWidth,
 		applyGestureEvent()
 
 		sliderContainer.addEventListener( 'click', ( e ) => {
-			if ( e.target.className === 'wp-gallery-fullscreen-slider-item' ||
+			if ( e.target.className === `${prefixClassname}-item` ||
 					e.target.tagName === 'IMG' ) {
 				toggleFocusMode()
 			}

--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -311,9 +311,15 @@ const clientWidth = window.innerWidth,
 			nextButton.style.visibility = 'hidden'
 		} else {
 			nextButton.addEventListener( 'click', () => {
-				renderNext()
+				if ( !items[ current ].querySelector( '.expanded' ) ) {
+					renderNext()
+				}
 			} )
-			previousButton.addEventListener( 'click', renderPrevious )
+			previousButton.addEventListener( 'click', () => {
+				if ( !items[ current ].querySelector( '.expanded' ) ) {
+					renderPrevious()
+				}
+			} )
 		}
 	}
 

--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -7,8 +7,7 @@ let current = 0,
 	dir = '',
 	lang,
 	gallery,
-	parentContainer,
-	focusMode = false
+	parentContainer
 
 const clientWidth = window.innerWidth,
 	prefixClassname = 'wp-gallery-fullscreen-slider',
@@ -221,17 +220,11 @@ const clientWidth = window.innerWidth,
 							renderImageInfo( mediaInfo, gallery[ index ], lang
 							) )
 
-						const insertedCaption = item.querySelector( `.${prefixClassname}-item-caption` ),
-							insertedAttribution = item.querySelector( `.${prefixClassname}-item-attribution` )
+						const insertedCaption = item.querySelector( `.${prefixClassname}-item-caption` )
 
 						insertedCaption.addEventListener( 'click', () => {
 							handleCaptionExpansion( item )
 						} )
-
-						if ( focusMode ) {
-							insertedCaption.classList.add( `${prefixClassname}-focus-mode` )
-							insertedAttribution.classList.add( `${prefixClassname}-focus-mode` )
-						}
 					}
 				} )
 		}
@@ -324,23 +317,8 @@ const clientWidth = window.innerWidth,
 	},
 
 	toggleFocusMode = () => {
-		const toggleElements = [
-			'.wp-gallery-fullscreen-close',
-			'.previous',
-			'.next',
-			`.${prefixClassname}-item-caption`,
-			`.${prefixClassname}-item-attribution`
-		]
-
-		focusMode = !focusMode
-		toggleElements.forEach( elementName => {
-			Array.prototype.forEach.call(
-				parentContainer.querySelectorAll( elementName ),
-				element => {
-					element.classList.toggle( `${prefixClassname}-focus-mode` )
-				}
-			)
-		} )
+		const gallery = parentContainer.querySelector( '.wp-gallery-fullscreen' )
+		gallery.classList.toggle( 'wp-gallery-fullscreen-focus-mode' )
 	},
 
 	onShowFn = () => {

--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -317,14 +317,10 @@ const clientWidth = window.innerWidth,
 			nextButton.style.visibility = 'hidden'
 		} else {
 			nextButton.addEventListener( 'click', () => {
-				if ( !items[ current ].querySelector( '.expanded' ) ) {
-					renderNext()
-				}
+				renderNext()
 			} )
 			previousButton.addEventListener( 'click', () => {
-				if ( !items[ current ].querySelector( '.expanded' ) ) {
-					renderPrevious()
-				}
+				renderPrevious()
 			} )
 		}
 	}

--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -255,10 +255,12 @@ const clientWidth = window.innerWidth,
 
 		const container = parentContainer.querySelector( `.${prefixClassname}` ),
 			marginLR = dir === 'ltr' ? 'marginLeft' : 'marginRight',
-			captionText = `${prefixClassname}-item-caption-text`
+			captionText = `${prefixClassname}-item-caption-text`,
+			items = container.querySelectorAll( `.${prefixClassname}-item` )
 
 		container.addEventListener( 'touchstart', e => {
-			if ( e.target.className === captionText ) {
+			if ( e.target.className === captionText &&
+				items[ current ].querySelector( `.${prefixClassname}-item-caption-expand-cue` ) ) {
 				return
 			}
 
@@ -273,7 +275,8 @@ const clientWidth = window.innerWidth,
 			container.style.transition = 'unset'
 		} )
 		container.addEventListener( 'touchmove', e => {
-			if ( e.target.className === captionText ) {
+			if ( e.target.className === captionText &&
+				items[ current ].querySelector( `.${prefixClassname}-item-caption-expand-cue` ) ) {
 				return
 			}
 			const clientX = e.touches[ 0 ].clientX,
@@ -283,7 +286,8 @@ const clientWidth = window.innerWidth,
 			e.preventDefault()
 		} )
 		container.addEventListener( 'touchend', e => {
-			if ( e.target.className === captionText ) {
+			if ( e.target.className === captionText &&
+				items[ current ].querySelector( `.${prefixClassname}-item-caption-expand-cue` ) ) {
 				return
 			}
 			container.style.transition = temp.originalTransition

--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -198,17 +198,19 @@ const clientWidth = window.innerWidth,
 							renderImageInfo( mediaInfo, gallery[ index ], lang
 							) )
 
-						const insertedCaption = item.querySelector( `.${prefixClassname}-item-caption` )
+						const insertedCaption = item.querySelector( `.${prefixClassname}-item-caption` ),
+							insertedCaptionText = item.querySelector( `.${prefixClassname}-item-caption-text` )
+
 						insertedCaption.addEventListener( 'click', () => {
 							const expandCue = item.querySelector( `.${prefixClassname}-item-caption-expand-cue` ),
 								expanded = insertedCaption.querySelector( '.expanded' )
 
 							if ( expandCue && expanded ) {
 								expandCue.classList.remove( 'expanded' )
-								insertedCaption.style.maxHeight = '95px'
+								insertedCaptionText.style.maxHeight = '80px'
 							} else if ( expandCue ) {
 								expandCue.classList.add( 'expanded' )
-								insertedCaption.style.maxHeight = '41.2%'
+								insertedCaptionText.style.maxHeight = '241px'
 							}
 						} )
 					}

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -28,7 +28,7 @@
 }
 
 .wp-gallery-fullscreen {
-	background-color: #222;
+	background-color: #202122;
 	z-index: @popup-z-index;
 	position: fixed;
 	width: 100%;
@@ -116,7 +116,7 @@
 
 			&-attribution {
 				position: absolute;
-				background-color: #222;
+				background-color: #202122;
 				bottom: 0;
 				width: 100%;
 				font-size: 16px;

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -334,6 +334,10 @@
 				z-index: @popup-z-index;
 			}
 		}
+
+		&-focus-mode {
+			visibility: hidden;
+		}
 	}
 
 	&-bottom {

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -1,13 +1,5 @@
 @popup-z-index: 110;
 
-// @todo this needs rename to avoid collison with client site
-.license {
-	background-repeat: no-repeat;
-	width: 14px;
-	height: 14px;
-	margin-right: 8px;
-}
-
 .wikipediapreview {
 	&-gallery {
 		display: flex;
@@ -88,18 +80,36 @@
 
 			&-caption {
 				position: absolute;
-				background-color: #222;
-				bottom: 35px;
+				background-color: rgba( 32, 33, 34, 0.6 );
+				bottom: 59px;
 				width: calc( 100vw + 1px );
 				font-size: 16px;
 				line-height: 1.56;
 				color: #f8f9fa;
-				overflow: scroll;
-				height: 80px;
+				overflow-y: scroll;
+				max-height: 95px;
+				transition: max-height 0.25s ease-in-out;
+
+				&-expand-cue {
+					width: 37px;
+					height: 2px;
+					background-color: #fff;
+					margin: auto;
+					margin-top: 10px;
+
+					&.expanded {
+						background-image: inline-svg( '../images/caption-cue-expanded.svg' );
+						background-repeat: no-repeat;
+						width: 37px;
+						height: 8px;
+						background-color: transparent;
+					}
+				}
 
 				&-text {
 					padding-left: 13px;
 					padding-right: 13px;
+					margin-top: 10px;
 				}
 			}
 
@@ -125,27 +135,27 @@
 
 					&-cc {
 						background-image: inline-svg( '../images/attribution-cc.svg' );
-						&:extend( .license );
+						&:extend( .wp-gallery-fullscreen-slider-item-attribution-info-license );
 					}
 
 					&-by {
 						background-image: inline-svg( '../images/attribution-author.svg' );
-						&:extend( .license );
+						&:extend( .wp-gallery-fullscreen-slider-item-attribution-info-license );
 					}
 
 					&-sa {
 						background-image: inline-svg( '../images/attribution-icon-share-a-like.svg' );
-						&:extend( .license );
+						&:extend( .wp-gallery-fullscreen-slider-item-attribution-info-license );
 					}
 
 					&-fair {
 						background-image: inline-svg( '../images/attribution-license-generic-gnu-free.svg' );
-						&:extend( .license );
+						&:extend( .wp-gallery-fullscreen-slider-item-attribution-info-license );
 					}
 
 					&-public {
 						background-image: inline-svg( '../images/attribution-license-public-domain.svg' );
-						&:extend( .license );
+						&:extend( .wp-gallery-fullscreen-slider-item-attribution-info-license );
 					}
 
 					&-author {
@@ -471,4 +481,11 @@
 			}
 		}
 	}
+}
+
+.wp-gallery-fullscreen-slider-item-attribution-info-license {
+	background-repeat: no-repeat;
+	width: 14px;
+	height: 14px;
+	margin-right: 8px;
 }

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -334,10 +334,6 @@
 				z-index: @popup-z-index;
 			}
 		}
-
-		&-focus-mode {
-			visibility: hidden;
-		}
 	}
 
 	&-bottom {
@@ -452,6 +448,16 @@
 					transform: scale( 1 );
 				}
 			}
+		}
+	}
+
+	&-focus-mode {
+		.previous,
+		.next,
+		.wp-gallery-fullscreen-close,
+		.wp-gallery-fullscreen-slider-item-caption,
+		.wp-gallery-fullscreen-slider-item-attribution {
+			visibility: hidden;
 		}
 	}
 

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -82,7 +82,6 @@
 				line-height: 1.56;
 				color: #f8f9fa;
 				max-height: 41.2%;
-				transition: max-height 0.25s ease-in-out;
 
 				&-expand-cue {
 					width: 37px;
@@ -106,6 +105,7 @@
 					margin-top: 10px;
 					max-height: 80px;
 					overflow-y: scroll;
+					transition: max-height 0.25s ease-in-out;
 				}
 
 				&::-webkit-scrollbar {

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -86,8 +86,7 @@
 				font-size: 16px;
 				line-height: 1.56;
 				color: #f8f9fa;
-				overflow-y: scroll;
-				max-height: 95px;
+				max-height: 41.2%;
 				transition: max-height 0.25s ease-in-out;
 
 				&-expand-cue {
@@ -110,6 +109,8 @@
 					padding-left: 13px;
 					padding-right: 13px;
 					margin-top: 10px;
+					max-height: 80px;
+					overflow-y: scroll;
 				}
 			}
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T262373

The gallery focus mode allows users to hide all other information in the gallery with a single tap to only display the image itself. 

Note this PR builds on top of https://github.com/wikimedia/wikipedia-preview/pull/85, hence the commit list showing all commits. The only commit relevant to focus mode at this point is https://github.com/wikimedia/wikipedia-preview/commit/26d274382c88b8ef88edacd9d706ae3a04180a40. 

Let's aim to merge #85 first. 