### PR TITLE
Allow features partially supported

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,7 +3,8 @@
 	"plugins": ["stylelint-no-unsupported-browser-features"],
 	"rules": {
 		"plugin/no-unsupported-browser-features": [true, {
-			"severity": "warning"
+			"severity": "warning",
+			"ignorePartialSupport": true
 		}]
 	}
 }


### PR DESCRIPTION
Some web features that we rely on are only partially supported by IE11. The warnings emitted by the plugin are coming from a good place but are not relevant in this case.