### PR TITLE
T268057 hide info when it is not available and handle refresh event

### DIFF
--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -91,9 +91,9 @@ const clientWidth = window.innerWidth,
 					${getLicenseInfo( mediaInfo.license )}
 					${ author ? `<div class="${prefixClassname}-item-attribution-info-author">${author}</div>` : ''}
 				</div>
-				<div class="${prefixClassname}-item-attribution-more-info">
+				${ link ? `<div class="${prefixClassname}-item-attribution-more-info">
 					<a href="${link}" class="${prefixClassname}-item-attribution-more-info-link" target="_blank"></a>
-				</div>
+				</div>` : '' }
 			</div>
 		`.trim()
 	},
@@ -108,9 +108,17 @@ const clientWidth = window.innerWidth,
 				items = slider.querySelectorAll( `.${prefixClassname}-item` )
 
 			items.forEach( item => {
-				const image = item.querySelector( 'img' )
+				const image = item.querySelector( 'img' ),
+					caption = item.querySelector( `.${prefixClassname}-item-caption` ),
+					attribution = item.querySelector( `.${prefixClassname}-item-attribution` )
 				if ( image ) {
 					item.removeChild( image )
+				}
+				if ( caption ) {
+					item.removeChild( caption )
+				}
+				if ( attribution ) {
+					item.removeChild( attribution )
 				}
 			} )
 


### PR DESCRIPTION
Phabricator : https://phabricator.wikimedia.org/T268057

Problem
===

The info icon is shown when the source link is not found from the api response

Solution
===

Simply hide the info element when there is no link given. However, it isn't idea when the page is **given offline then online** due to the reason how we design to refresh the image + info, therefore addition action during refresh image event.