### PR TITLE
Ignore hover for link with open popup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ function init( {
 		showPopup = ( e, refresh = false ) => {
 			e.preventDefault()
 
-			const popupId = currentPopupId = Date.now(),
+			const popupId = Date.now(),
 				{ target } = refresh ? last : e,
 				title = refresh ? last.title : target.getAttribute( 'data-wp-title' ) || target.textContent,
 				lang = refresh ? last.lang : target.getAttribute( 'data-wp-lang' ) || globalLang,
@@ -33,6 +33,8 @@ function init( {
 				// Hovering over the same link and the popup is already open
 				return
 			}
+
+			currentPopupId = popupId
 
 			if ( popup.element.style.visibility === 'visible' ) {
 				popup.hide()

--- a/src/index.js
+++ b/src/index.js
@@ -21,15 +21,22 @@ function init( {
 		last = {},
 		showPopup = ( e, refresh = false ) => {
 			e.preventDefault()
-			if ( popup.element.style.visibility === 'visible' ) {
-				popup.hide()
-			}
+
 			const popupId = currentPopupId = Date.now(),
 				{ target } = refresh ? last : e,
 				title = refresh ? last.title : target.getAttribute( 'data-wp-title' ) || target.textContent,
 				lang = refresh ? last.lang : target.getAttribute( 'data-wp-lang' ) || globalLang,
 				pointerPosition = refresh ? last.pointerPosition : { x: e.clientX, y: e.clientY },
 				dir = getDir( lang )
+
+			if ( popup.element.currentTargetElement === target && !refresh ) {
+				// Hovering over the same link and the popup is already open
+				return
+			}
+
+			if ( popup.element.style.visibility === 'visible' ) {
+				popup.hide()
+			}
 
 			popup.loading = true
 			popup.dir = dir


### PR DESCRIPTION
https://phabricator.wikimedia.org/T259490

When a target element already has an open popup attached to it, ignore subsequent hovers.

This is causing multiple hook onOpen events for the same popup in #94.