### PR TITLE
T276281: Improve height setting when expanding down

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -49,21 +49,30 @@ export const customEvents = popup => {
 		},
 
 		setPreviewMaxHeight = ( max ) => {
-			const bodyElement = popup.element.querySelector( '.wikipediapreview-body' )
+			const bodyElement = popup.element.querySelector( '.wikipediapreview-body' ),
+				headerElement = popup.element.querySelector( '.wikipediapreview-header' ),
+				footerElement = popup.element.querySelector( '.wikipediapreview-footer-cta' ) || popup.element.querySelector( '.wikipediapreview-footer-loading' )
 
 			if ( !bodyElement ) {
 				return
 			}
 
 			if ( popup.element.style[ 2 ] === 'bottom' || popup.element.style.bottom ) {
+				// expand up
 				let currentTop = popup.element.getBoundingClientRect().top,
 					originalHeight = parseInt(
 						window.getComputedStyle( bodyElement ).maxHeight.slice( 0, -2 )
 					)
+
 				bodyElement.style.maxHeight = Math.min( max, originalHeight + currentTop ) + 'px'
 			} else {
 				// expand down
-				bodyElement.style.maxHeight = max + 'px'
+				let currentTop = popup.element.getBoundingClientRect().top,
+					headerHeight = window.getComputedStyle( headerElement ).height.slice( 0, -2 ),
+					footerHeight = window.getComputedStyle( footerElement ).height.slice( 0, -2 ),
+					availableHeight = window.innerHeight - currentTop - headerHeight - footerHeight
+
+				bodyElement.style.maxHeight = Math.min( max, availableHeight ) + 'px'
 			}
 		},
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T276281

## Problem 

When preview popup expands down with limited screen space, it's expanding too far down the screen and overflows the available screen space. 

## Solution

Let `setPreviewMaxHeight` also decide what's the most appropriate height when expanding down, similar to how we do it when expanding up.

