### PR TITLE
T278377: Add version logging method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Integrating Wikipedia Preview to your site consists of a three step process:
 2. Invoking `wikipediaPreview.init( <options> )`
 3. Annotating articles accordingly
 
-You can read more about each step below. Once Wikipedia Preview is set up correctly, you should see the version information being logged in your JS console.
+You can read more about each step below. Once Wikipedia Preview is set up correctly, you should see the version information being logged in your JS console. You can also invoke `wikipediaPreview.version()` from your JS console to view version information at any time. 
 
 ### Standalone Script
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Android | 4.1+
 
 ## Getting Started
 
+Integrating Wikipedia Preview to your site consists of a three step process:
+
+1. Loading wikipedia-preview.js (either as a standalong script or an npm dependency)
+2. Invoking `wikipediaPreview.init( <options> )`
+3. Annotating articles accordingly
+
+You can read more about each step below. Once Wikipedia Preview is set up correctly, you should see the version information being logged in your JS console.
+
 ### Standalone Script
 
 ```html

--- a/src/index.js
+++ b/src/index.js
@@ -6,16 +6,21 @@ import { renderPreview, renderLoading, renderError, renderDisambiguation, render
 import { getWikipediaAttrFromUrl, isTouch, getDir, isOnline } from './utils'
 
 const invokeCallback = ( events, name, params ) => {
-	const callback = events && events[ name ]
-	if ( callback instanceof Function ) {
-		try {
-			callback.apply( null, params )
-		} catch ( e ) {
-			// eslint-disable-next-line no-console
-			console.log( 'Error invoking Wikipedia Preview custom callback', e )
+		const callback = events && events[ name ]
+		if ( callback instanceof Function ) {
+			try {
+				callback.apply( null, params )
+			} catch ( e ) {
+				// eslint-disable-next-line no-console
+				console.log( 'Error invoking Wikipedia Preview custom callback', e )
+			}
 		}
+	},
+
+	version = () => {
+	/* eslint-disable-next-line no-undef, no-console */
+		console.log( `Wikipedia Preview - ${APP_VERSION} (${CIRCLE_SHA1})` )
 	}
-}
 
 let currentPopupId
 
@@ -146,6 +151,8 @@ function init( {
 			}
 		)
 	}
+
+	version()
 }
 
 export { init }

--- a/src/index.js
+++ b/src/index.js
@@ -150,4 +150,4 @@ function init( {
 
 version()
 
-export { init }
+export { init, version }

--- a/src/index.js
+++ b/src/index.js
@@ -3,24 +3,19 @@ import { customEvents } from './event'
 import { createPopup } from './popup'
 import { createTouchPopup } from './touchPopup'
 import { renderPreview, renderLoading, renderError, renderDisambiguation, renderOffline } from './preview'
-import { getWikipediaAttrFromUrl, isTouch, getDir, isOnline } from './utils'
+import { getWikipediaAttrFromUrl, isTouch, getDir, isOnline, version } from './utils'
 
 const invokeCallback = ( events, name, params ) => {
-		const callback = events && events[ name ]
-		if ( callback instanceof Function ) {
-			try {
-				callback.apply( null, params )
-			} catch ( e ) {
-				// eslint-disable-next-line no-console
-				console.log( 'Error invoking Wikipedia Preview custom callback', e )
-			}
+	const callback = events && events[ name ]
+	if ( callback instanceof Function ) {
+		try {
+			callback.apply( null, params )
+		} catch ( e ) {
+			// eslint-disable-next-line no-console
+			console.log( 'Error invoking Wikipedia Preview custom callback', e )
 		}
-	},
-
-	version = () => {
-	/* eslint-disable-next-line no-undef, no-console */
-		console.log( `Wikipedia Preview - ${APP_VERSION} (${CIRCLE_SHA1})` )
 	}
+}
 
 let currentPopupId
 
@@ -151,8 +146,8 @@ function init( {
 			}
 		)
 	}
-
-	version()
 }
+
+version()
 
 export { init }

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,4 +73,9 @@ export const getWikipediaAttrFromUrl = url => {
 
 	buildWikipediaUrl = ( lang, title, touch ) => {
 		return `https://${lang}${ touch ? '.m' : '' }.wikipedia.org/wiki/${encodeURIComponent( title )}?${getAnalyticsQueryParam()}`
+	},
+
+	version = () => {
+		/* eslint-disable-next-line no-undef, no-console */
+		console.log( `Wikipedia Preview - version ${APP_VERSION} (${CIRCLE_SHA1})` )
 	}

--- a/src/utils.js
+++ b/src/utils.js
@@ -77,5 +77,5 @@ export const getWikipediaAttrFromUrl = url => {
 
 	version = () => {
 		/* eslint-disable-next-line no-undef, no-console */
-		console.log( `Wikipedia Preview - version ${APP_VERSION} (${CIRCLE_SHA1})` )
+		console.log( `Wikipedia Preview - version ${APP_VERSION} (${GIT_HASH})` )
 	}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack')
+const childProcess = require('child_process')
 const fs = require('fs')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const LessPluginInlineSvg = require('less-plugin-inline-svg');
@@ -43,7 +44,7 @@ const config = {
       }),
       new webpack.DefinePlugin({
         APP_VERSION: JSON.stringify(JSON.parse(fs.readFileSync('./package.json')).version),
-        CIRCLE_SHA1: JSON.stringify(process.env.CIRCLE_SHA1 || '-')
+        GIT_HASH: JSON.stringify(childProcess.execSync('git rev-parse --short HEAD').toString().trim())
       }),
     ],
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+const webpack = require('webpack')
+const fs = require('fs')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const LessPluginInlineSvg = require('less-plugin-inline-svg');
 const IgnoreEmitPlugin = require('ignore-emit-webpack-plugin');
@@ -38,7 +40,11 @@ const config = {
       new BundleAnalyzerPlugin({
         analyzerMode: 'disabled',
         generateStatsFile: true
-      })
+      }),
+      new webpack.DefinePlugin({
+        APP_VERSION: JSON.stringify(JSON.parse(fs.readFileSync('./package.json')).version),
+        CIRCLE_SHA1: JSON.stringify(process.env.CIRCLE_SHA1 || '-')
+      }),
     ],
   module: {
     rules: [


### PR DESCRIPTION
https://phabricator.wikimedia.org/T278377

### Objective

Wikipedia Preview should print its version number to the javascript console, as that is useful information when a partner requests support. 

