### PR TITLE
Smoothen gallery closing animation

### DIFF
--- a/images/caption-cue.svg
+++ b/images/caption-cue.svg
@@ -1,0 +1,1 @@
+<svg width="37" height="3" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0 1h36.5M0 2h36.5" stroke="#fff"/></svg>

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -85,24 +85,25 @@
 
 				&-expand-cue {
 					width: 37px;
-					height: 2px;
-					background-color: #fff;
+					height: 3px;
+					background-image: inline-svg( '../images/caption-cue.svg' );
+					background-repeat: no-repeat;
+					background-color: transparent;
 					margin: auto;
 					margin-top: 10px;
+					padding-bottom: 4px;
+					transition: height 0.25s ease-in-out;
 
 					&.expanded {
 						background-image: inline-svg( '../images/caption-cue-expanded.svg' );
-						background-repeat: no-repeat;
-						width: 37px;
 						height: 8px;
-						background-color: transparent;
 					}
 				}
 
 				&-text {
 					padding-left: 13px;
 					padding-right: 13px;
-					margin-top: 10px;
+					margin-top: 6px;
 					max-height: 80px;
 					overflow-y: scroll;
 					transition: max-height 0.25s ease-in-out;


### PR DESCRIPTION
https://phabricator.wikimedia.org/T269854

### Problem

The gallery caption transition from expanded to collapsed is awkward because there's a `transition` rule for the caption text but not for the caption expand cue. 

### Solution

I'm updating the collapsed state of the expand cue with an SVG (`svgo` ready) so that we can set a `transition` rule for the expand cue itself to go along with the caption text. This makes the overall animation smoother. 

