### PR TITLE
T281512 Wikipedia Preview english demo doesn't work in IE 11

### DIFF
--- a/demo/articles/english.html
+++ b/demo/articles/english.html
@@ -58,10 +58,10 @@
                 lang: 'en',
                 events: {
                     onShow: function(title, lang, type) {
-                        console.log(`Opening ${type} popup for article ${title} in ${lang}`)
+                        console.log( 'Opening ' + type + ' popup for article ' + title + ' in ' + lang )
                     },
                     onWikiRead: function(title, lang) {
-                        console.log(`Going to read article ${title} in ${lang} on Wikipedia`)
+                        console.log( 'Going to read article ' + title + ' in ' + lang + ' on Wikipedia' )
                     }
                 }
             });


### PR DESCRIPTION
Phabricator Ticket : https://phabricator.wikimedia.org/T281512

https://wikimedia.github.io/wikipedia-preview/demo/articles/english.html
as title, fix it