### PR TITLE
T282675 URL encode issue on wp-preview

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ function init( {
 
 		const popupId = Date.now()
 		const { target } = refresh ? last : e
-		const title = refresh ? last.title : target.getAttribute( 'data-wp-title' ) || target.textContent
+		const title = refresh ? last.title : decodeURIComponent( target.getAttribute( 'data-wp-title' ) || target.textContent )
 		const localLang = refresh ? last.lang : target.getAttribute( 'data-wp-lang' ) || globalLang
 		const pointerPosition = refresh ? last.pointerPosition : { x: e.clientX, y: e.clientY }
 		const dir = getDir( localLang )

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -63,7 +63,6 @@ describe( 'requestPagePreview', () => {
 			assert( url.includes( "L'%C3%89poque%20des%20Ch%C3%A2teaux" ) )
 		} )
 	} )
-
 } )
 
 describe( 'requestPageMedia', () => {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -64,11 +64,6 @@ describe( 'requestPagePreview', () => {
 		} )
 	} )
 
-	it( 'do not encode the encoded title in the URL', () => {
-		requestPagePreview( 'fr', "L'%C3%89poque%20des%20Ch%C3%A2teaux", false, () => {}, ( url ) => {
-			assert( url.includes( "L'%C3%89poque%20des%20Ch%C3%A2teaux" ) )
-		} )
-	} )
 } )
 
 describe( 'requestPageMedia', () => {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -63,6 +63,12 @@ describe( 'requestPagePreview', () => {
 			assert( url.includes( "L'%C3%89poque%20des%20Ch%C3%A2teaux" ) )
 		} )
 	} )
+
+	it( 'do not encode the encoded title in the URL', () => {
+		requestPagePreview( 'fr', "L'%C3%89poque%20des%20Ch%C3%A2teaux", false, () => {}, ( url ) => {
+			assert( url.includes( "L'%C3%89poque%20des%20Ch%C3%A2teaux" ) )
+		} )
+	} )
 } )
 
 describe( 'requestPageMedia', () => {


### PR DESCRIPTION
Phabricator Ticket: https://phabricator.wikimedia.org/T282675

Solution : According to what I found on Popups extension, decode when we get the title.
