### PR TITLE
T282717 Add target stories for hyperlink, image and text

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,7 @@
+const webpack = require('webpack')
 const path = require('path');
 
-const custom = require('../webpack.config.js')(null, {mode: 'dev'});
+const custom = require('../webpack.config.js')(null, {mode: 'development'});
 
 module.exports = {
   "stories": [
@@ -11,6 +12,18 @@ module.exports = {
     "@storybook/addon-essentials"
   ],
   webpackFinal: (config) => {
-    return { ...config, module: { ...config.module, rules: custom.module.rules } };
+    return {
+      ...config,
+      plugins: [
+        ...config.plugins,
+        new webpack.DefinePlugin( {
+          APP_VERSION: '"(mock app version)"',
+          GIT_HASH: '"(mock git hash)"'
+        } ) ],
+      module: {
+        ...config.module,
+        rules: custom.module.rules
+      }
+    };
   },
 }

--- a/src/stories/target.stories.js
+++ b/src/stories/target.stories.js
@@ -1,0 +1,52 @@
+import { buildWikipediaUrl } from '../utils'
+import { init } from '../index'
+
+export default {
+	title: 'Target Cases',
+	argTypes: {
+		lang: {
+			name: 'Language',
+			defaultValue: 'en',
+			control: {
+				type: 'select',
+				options: [ 'en', 'fr', 'hi', 'ks', 'he' ]
+			}
+		},
+		title: {
+			name: 'Article Title',
+			defaultValue: 'Cat',
+			control: 'text'
+		}
+	}
+
+}
+
+export const Hyperlink = ( { lang, title } ) => {
+	const container = document.createElement( 'div' )
+	const template = `<a href="${buildWikipediaUrl( lang, title, true, false )}">${title} (${lang})</a>`
+	container.innerHTML = template
+	container.onmouseover = () => {
+		init( { root: document.getElementById( 'root' ), detectLinks: true } )
+	}
+	return container
+}
+
+export const Image = ( { lang, title } ) => {
+	const container = document.createElement( 'div' )
+	const template = `<a href="${buildWikipediaUrl( lang, title, true, false )}"><img src="https://upload.wikimedia.org/wikipedia/commons/3/3d/Wikipedia-logo-v2.png"></a>`
+	container.innerHTML = template
+	container.onmouseover = () => {
+		init( { root: document.getElementById( 'root' ), detectLinks: true } )
+	}
+	return container
+}
+
+export const Text = ( { lang, title } ) => {
+	const container = document.createElement( 'div' )
+	const template = `<span class="wmf-wp-with-preview" data-wikipedia-preview data-wp-title="${title}">${title} (${lang})</span>`
+	container.innerHTML = template
+	container.onmouseover = () => {
+		init( { root: document.getElementById( 'root' ), lang } )
+	}
+	return container
+}

--- a/src/stories/target.stories.js
+++ b/src/stories/target.stories.js
@@ -18,7 +18,6 @@ export default {
 			control: 'text'
 		}
 	}
-
 }
 
 export const Hyperlink = ( { lang, title } ) => {

--- a/src/stories/target.stories.js
+++ b/src/stories/target.stories.js
@@ -2,7 +2,7 @@ import { buildWikipediaUrl } from '../utils'
 import { init } from '../index'
 
 export default {
-	title: 'Target Cases',
+	title: 'Targets',
 	argTypes: {
 		lang: {
 			name: 'Language',

--- a/src/stories/target.stories.js
+++ b/src/stories/target.stories.js
@@ -24,9 +24,7 @@ export const Hyperlink = ( { lang, title } ) => {
 	const container = document.createElement( 'div' )
 	const template = `<a href="${buildWikipediaUrl( lang, title, true, false )}">${title} (${lang})</a>`
 	container.innerHTML = template
-	container.onmouseover = () => {
-		init( { root: document.getElementById( 'root' ), detectLinks: true } )
-	}
+	init( { root: container, detectLinks: true } )
 	return container
 }
 
@@ -34,9 +32,7 @@ export const Image = ( { lang, title } ) => {
 	const container = document.createElement( 'div' )
 	const template = `<a href="${buildWikipediaUrl( lang, title, true, false )}"><img src="https://upload.wikimedia.org/wikipedia/commons/3/3d/Wikipedia-logo-v2.png"></a>`
 	container.innerHTML = template
-	container.onmouseover = () => {
-		init( { root: document.getElementById( 'root' ), detectLinks: true } )
-	}
+	init( { root: container, detectLinks: true } )
 	return container
 }
 
@@ -44,8 +40,6 @@ export const Text = ( { lang, title } ) => {
 	const container = document.createElement( 'div' )
 	const template = `<span class="wmf-wp-with-preview" data-wikipedia-preview data-wp-title="${title}">${title} (${lang})</span>`
 	container.innerHTML = template
-	container.onmouseover = () => {
-		init( { root: document.getElementById( 'root' ), lang } )
-	}
+	init( { root: container, lang } )
 	return container
 }


### PR DESCRIPTION
Phabricator Ticket: https://phabricator.wikimedia.org/T282717

 - [x] add target stories
 - [x] (Out ot scope, move to another ticket) add image in the demo page as the example

<img src="https://user-images.githubusercontent.com/2560096/120716091-d967ec00-c4c5-11eb-816a-4e4caef924ac.png" width="500"/>
