### PR TITLE
T285667: Add styling for unordered lists 

### DIFF
--- a/style/preview.less
+++ b/style/preview.less
@@ -94,6 +94,12 @@
 			padding: 10px 20px;
 		}
 
+		ul {
+			padding-left: 35px;
+			padding-right: 35px;
+			line-height: 1.6;
+		}
+
 		&-message {
 			display: flex;
 			margin-left: 23px;

--- a/style/preview.less
+++ b/style/preview.less
@@ -96,7 +96,7 @@
 
 		ul {
 			padding-left: 35px;
-			padding-right: 35px;
+			padding-right: 20px;
 			line-height: 1.6;
 		}
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T285667 

We were missing styling support for unordered lists (aka bullet points).  Added padding so the bullet points line up with the paragraph above, as well as the same paragraph line height.

Before | After
------  | ------
<img width="389" alt="image" src="https://user-images.githubusercontent.com/4752599/125352233-00200a80-e32f-11eb-97ac-a967dc2bd6d2.png"> | <img width="311" alt="image" src="https://user-images.githubusercontent.com/4752599/125351898-a7507200-e32e-11eb-8d5c-f8d59fbfb3af.png">






