### PR TITLE
T286654 The Gallery / wp-dark-screen are hidden

### DIFF
--- a/style/gallery.less
+++ b/style/gallery.less
@@ -1,4 +1,4 @@
-@popup-z-index: 110;
+@popup-z-index: 1100;
 
 .wikipediapreview {
 	&-gallery {

--- a/style/popup.less
+++ b/style/popup.less
@@ -1,4 +1,4 @@
-@popup-z-index: 110;
+@popup-z-index: 1100;
 
 .wp-popup {
 	box-sizing: border-box;
@@ -27,8 +27,8 @@
 	background-color: rgba( 0, 0, 0, 0.7 );
 	z-index: @popup-z-index - 10;
 	position: fixed;
-	width: 100%;
-	height: 100%;
 	left: 0;
+	right: 0;
 	top: 0;
+	bottom: 0;
 }


### PR DESCRIPTION
Phabricator Ticket: https://phabricator.wikimedia.org/T286654

the z-index 110 is too low, update it to 1100 to cover most of the cases, and update how bootstrap works for dark background screen.

[Bootstrap modal is 1050](https://github.com/twbs/bootstrap/blob/main/scss/_variables.scss#L1036), so 1100 should be enough for us.