### PR TITLE
Handle no-footer case (error state)

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -69,7 +69,8 @@ export const customEvents = popup => {
 			// expand down
 			const currentTop = popup.element.getBoundingClientRect().top
 			const headerHeight = window.getComputedStyle( headerElement ).height.slice( 0, -2 )
-			const footerHeight = window.getComputedStyle( footerElement ).height.slice( 0, -2 )
+			const footerHeight = footerElement ?
+				window.getComputedStyle( footerElement ).height.slice( 0, -2 ) : 0
 			const availableHeight = window.innerHeight - currentTop - headerHeight - footerHeight
 
 			bodyElement.style.maxHeight = Math.min( max, availableHeight ) + 'px'


### PR DESCRIPTION
The error state has no footer component. The code trying to set the preview max height breaks on it.

Assume a footer height of 0 when it is not there.