### PR TITLE
detectLinks: Leave href alone for right-click options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,8 +146,6 @@ function init( {
 					node.setAttribute( 'data-wp-title', matches.title )
 					node.setAttribute( 'data-wp-lang', matches.lang )
 					if ( isTouch ) {
-						// eslint-disable-next-line no-script-url
-						node.setAttribute( 'href', 'javascript:;' )
 						node.addEventListener( 'click', showPopup )
 					} else {
 						node.addEventListener( 'mouseenter', showPopup )


### PR DESCRIPTION
https://phabricator.wikimedia.org/T288034

The `detectLinks` init option replaces the href attribute value with the standard no-op `javascript:;` in touch mode. It makes it impossible to use the standard right click options (like open in new tab) on devices that have both touch support and a pointer.

I removed the href replacement. I don't know why it was there. Please test carefully.