### PR TITLE
Removed a condition in Cypress Test Cases

### DIFF
--- a/cypress/integration/gallery-spec.js
+++ b/cypress/integration/gallery-spec.js
@@ -21,15 +21,13 @@ describe( 'Check the Gallery Pages ', () => {
 		} )
 		const i = 0
 		// Check if the Images exist
-		preview.getBodyGalleryImages().its( 'length' ).then( res => {
-			if ( res > 0 ) {
-				// Open the Gallery and Close it
-				preview.getBodyGalleryImages().first().click()
-				// Check the Gallery Page
-				gallery.checkGalleryPage( i )
-				// Close the Gallery
-				gallery.getGalleryCloseBtn().click()
-			}
+		preview.getBodyGalleryImages().its( 'length' ).then( () => {
+			// Open the Gallery and Close it
+			preview.getBodyGalleryImages().first().click()
+			// Check the Gallery Page
+			gallery.checkGalleryPage( i )
+			// Close the Gallery
+			gallery.getGalleryCloseBtn().click()
 		} )
 	} )
 
@@ -44,23 +42,21 @@ describe( 'Check the Gallery Pages ', () => {
 		} )
 		const i = 0
 		// Check if the Image exist
-		preview.getBodyGalleryImages().its( 'length' ).then( res => {
-			if ( res > 1 ) {
-				// Open the Gallery
-				preview.getBodyGalleryImages().first().click()
-				// Check the Current Gallery Page
-				gallery.checkGalleryPage( i )
-				// Click on the Next Icon
-				gallery.getGalleryNextBtn().click()
-				// Check the Next Gallery Page
-				gallery.checkGalleryPage( i + 1 )
-				// Click on the Previous Icon
-				gallery.getGalleryPrevBtn().click()
-				// Check the Previous Gallery Page
-				gallery.checkGalleryPage( i )
-				// Close the Gallery
-				gallery.getGalleryCloseBtn().click()
-			}
+		preview.getBodyGalleryImages().its( 'length' ).then( () => {
+			// Open the Gallery
+			preview.getBodyGalleryImages().first().click()
+			// Check the Current Gallery Page
+			gallery.checkGalleryPage( i )
+			// Click on the Next Icon
+			gallery.getGalleryNextBtn().click()
+			// Check the Next Gallery Page
+			gallery.checkGalleryPage( i + 1 )
+			// Click on the Previous Icon
+			gallery.getGalleryPrevBtn().click()
+			// Check the Previous Gallery Page
+			gallery.checkGalleryPage( i )
+			// Close the Gallery
+			gallery.getGalleryCloseBtn().click()
 		} )
 
 	} )

--- a/cypress/integration/mobile-gallery-spec.js
+++ b/cypress/integration/mobile-gallery-spec.js
@@ -21,21 +21,19 @@ describe( 'Check the Gallery Pages in Mobile View', () => {
 		} )
 		const i = 0
 		// Check if the Images exist
-		preview.getBodyGalleryImages().its( 'length' ).then( res => {
-			if ( res > 1 ) {
-				// Open the Gallery
-				preview.getBodyGalleryImages().first().click()
-				// Check the Gallery Page
-				gallery.checkGalleryPage( i )
-				// Click on the Next Icon
-				gallery.getGalleryNextBtn().click()
-				// Click on the Previous Icon
-				gallery.getGalleryPrevBtn().click()
-				// Close the Gallery
-				gallery.getGalleryCloseBtn().click()
-				// Close the Preview
-				preview.getHeaderClosebtn().click()
-			}
+		preview.getBodyGalleryImages().its( 'length' ).then( () => {
+			// Open the Gallery
+			preview.getBodyGalleryImages().first().click()
+			// Check the Gallery Page
+			gallery.checkGalleryPage( i )
+			// Click on the Next Icon
+			gallery.getGalleryNextBtn().click()
+			// Click on the Previous Icon
+			gallery.getGalleryPrevBtn().click()
+			// Close the Gallery
+			gallery.getGalleryCloseBtn().click()
+			// Close the Preview
+			preview.getHeaderClosebtn().click()
 		} )
 	} )
 
@@ -50,46 +48,15 @@ describe( 'Check the Gallery Pages in Mobile View', () => {
 		} )
 		const i = 0
 		// Check if the Images exist
-		preview.getBodyGalleryImages().its( 'length' ).then( res => {
-			if ( res > 1 ) {
-				// Open the Gallery
-				preview.getBodyGalleryImages().first().click()
-				// Check the Gallery Page
-				gallery.checkGalleryPage( i )
-				// Swipe to go Next
-				gallery.getGalleryImage( i ).swipe( 'right', 'left' )
-				// Swipe to go Previous
-				gallery.getGalleryImage( i + 1 ).swipe( 'left', 'right' )
-			}
-		} )
-	} )
-
-	it( 'Check the Gallery Image Caption Scrollable', () => {
-		// Open the Preview
-		preview.getPreviewSpan().eq( 4 ).click()
-		// Check for the Continue Reading exist
-		preview.getFooterContinueReading().then( res => {
-			if ( res.css( 'display' ) !== 'none' ) {
-				preview.getFooterContinueReading().click()
-			}
-		} )
-		const i = 1
-		// Check if the Images exist
-		preview.getBodyGalleryImages().its( 'length' ).then( res => {
-			if ( res > 1 ) {
-				// Open the Gallery
-				preview.getBodyGalleryImages().eq( 1 ).click()
-				// Check the Gallery Page
-				gallery.checkGalleryPage( i )
-				// Check if the Caption Bar exist
-				gallery.getGalleryCaptionBar( i ).its( 'length' ).then( len => {
-					if ( len > 0 ) {
-						// Scroll the Caption Text
-						gallery.getGalleryCaption( i ).swipe( 'bottom', 'center' )
-						// gallery.getGalleryCaptionText(i).scrollTo('bottom')
-					}
-				} )
-			}
+		preview.getBodyGalleryImages().its( 'length' ).then( () => {
+			// Open the Gallery
+			preview.getBodyGalleryImages().first().click()
+			// Check the Gallery Page
+			gallery.checkGalleryPage( i )
+			// Swipe to go Next
+			gallery.getGalleryImage( i ).swipe( 'right', 'left' )
+			// Swipe to go Previous
+			gallery.getGalleryImage( i + 1 ).swipe( 'left', 'right' )
 		} )
 	} )
 
@@ -104,21 +71,18 @@ describe( 'Check the Gallery Pages in Mobile View', () => {
 		} )
 		const i = 1
 		// Check if the Images exist
-		preview.getBodyGalleryImages().its( 'length' ).then( res => {
-			if ( res > 1 ) {
-				// Open the Gallery
-				preview.getBodyGalleryImages().eq( 1 ).click()
-				// Check the Gallery Page
-				gallery.checkGalleryPage( i )
-				// Check if the Caption Bar exist
-				gallery.getGalleryCaptionBar( i ).its( 'length' ).then( len => {
-					if ( len > 0 ) {
-						// Scroll the Caption Text
-						gallery.getGalleryCaptionBar( i ).click()
-						// gallery.getGalleryCaptionText(i).scrollTo('bottom')
-					}
-				} )
-			}
+		preview.getBodyGalleryImages().its( 'length' ).then( () => {
+			// Open the Gallery
+			preview.getBodyGalleryImages().eq( 1 ).click()
+			// Check the Gallery Page
+			gallery.checkGalleryPage( i )
+			// Check if the Caption Bar exist
+			gallery.getGalleryCaptionBar( i ).its( 'length' ).then( len => {
+				if ( len > 0 ) {
+					// Scroll the Caption Text
+					gallery.getGalleryCaptionBar( i ).click()
+				}
+			} )
 		} )
 	} )
 


### PR DESCRIPTION
The above PR is created to remove a condition (res>1) that is preset in gallery-spec and mobile-gallery-spec. The condition checks the number of images to be above zero such that our test cases run. But now we have chosen words in the preview that always contain images. Thereby, I have removed the condition.