### PR TITLE
Handle the offline state having no cta footer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,9 +111,12 @@ function init( {
 						} )
 					}
 				}
-				popup.element.querySelector( '.wikipediapreview-footer-cta-readonwiki, .wikipediapreview-cta-readonwiki' ).addEventListener( 'click', () => {
-					invokeCallback( events, 'onWikiRead', [ title, localLang ] )
-				} )
+				const readOnWikiCta = popup.element.querySelector( '.wikipediapreview-footer-cta-readonwiki, .wikipediapreview-cta-readonwiki' )
+				if ( readOnWikiCta ) {
+					readOnWikiCta.addEventListener( 'click', () => {
+						invokeCallback( events, 'onWikiRead', [ title, localLang ] )
+					} )
+				}
 			}
 		} )
 	}


### PR DESCRIPTION
The offline state doesn't have a footer with the "read on wiki" CTA. The code that tries to bind an even to that CTA crashes.