### PR TITLE
Log errors to the console

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,6 +6,7 @@
     "gallery-loading-still": "Still loading",
     "gallery-unknown-author": "Author unknown",
     "preview-error-message": "There was an issue while displaying this preview.",
+    "preview-console-error-message": "Preview unavailable for article '$1' (Language: $2)",
     "read-on-wiki": "Read on Wikipedia",
     "read-more": "Read more on Wikipedia",
     "preview-disambiguation-message": "Title <strong>$1</strong> is related to more than one article on Wikipedia.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -11,6 +11,7 @@
 	"gallery-loading-still": "Message shown 5 seconds after a fullscreen gallery image starts loading",
 	"gallery-unknown-author": "Message shown if image author is unknown",
 	"preview-error-message": "Message shown with a preview loading error",
+	"preview-console-error-message": "Message shown in the JavaScript console when a preview cannot be shown due to an error. Params: \n* $1 - Title of the article.\n* $2 - Language code of the article.",
 	"read-on-wiki": "Message shown in the Call to Action (CTA) of a preview loading error or disambiguation page",
 	"read-more": "The message shown in the footer part of the preview popup that brings user to the wikipedia page to read more about the article",
 	"preview-disambiguation-message": "The message shown for disambiguation pages. Params: \n* $1 - Title of the disambiguation page.",

--- a/src/api.js
+++ b/src/api.js
@@ -37,7 +37,7 @@ const requestPcsSummary = ( lang, title, callback, request = cachedRequest ) => 
 	const url = `https://${lang}.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent( title )}?${getAnalyticsQueryParam()}`
 	request( url, ( data, err ) => {
 		if ( !data ) {
-			logError( `Preview unavailable for article ${lang}:${title}. Unexpected error: `, err )
+			logError( msg( lang, 'preview-console-error-message', title, lang ), err )
 			return false
 		}
 		if ( data.type === 'standard' || data.type === 'disambiguation' ) {
@@ -59,7 +59,7 @@ const requestPcsSummary = ( lang, title, callback, request = cachedRequest ) => 
 				type: 'standard'
 			}
 		}
-		logError( `Preview unavailable for article ${lang}:${title}. More info: `, data )
+		logError( msg( lang, 'preview-console-error-message', title, lang ), data )
 		return false
 	}, callback )
 

--- a/src/api.js
+++ b/src/api.js
@@ -1,8 +1,9 @@
 import { cachedRequest } from './cachedRequest'
 import {
-	buildMwApiUrl, convertUrlToMobile,
+	buildMwApiUrl, convertUrlToMobile, logError,
 	strip, getDeviceSize, sanitizeHTML, getAnalyticsQueryParam
 } from './utils'
+import { msg } from './i18n'
 
 const requestPagePreview = ( lang, title, isTouch, callback, request = cachedRequest ) => {
 	const url = `https://${lang}.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent( title )}?${getAnalyticsQueryParam()}`
@@ -17,6 +18,7 @@ const requestPagePreview = ( lang, title, isTouch, callback, request = cachedReq
 				type: data.type
 			}
 		}
+		logError( `Preview unavailable for article ${lang}:${title}.`, data )
 		return false
 	}, callback )
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,8 +72,12 @@ const version = () => {
 	console.log( `Wikipedia Preview - version ${APP_VERSION} (${GIT_HASH})` )
 }
 
+const logError = ( ...err ) => {
+	console.error.apply( console, err ) // eslint-disable-line no-console
+}
+
 export {
 	getWikipediaAttrFromUrl, isTouch, isOnline, getDir, buildMwApiUrl,
 	convertUrlToMobile, strip, sanitizeHTML, getDeviceSize, getAnalyticsQueryParam,
-	buildWikipediaUrl, version
+	buildWikipediaUrl, version, logError
 }


### PR DESCRIPTION
The error state shouldn't happen too often but when it does, it's almost certainly caused by a configuration error. 

With this PR, editors and integrators get a little more information that they can try to understand or send us when they are stuck with unexpected error states.