### PR TITLE
Remove invisible spans from HTML

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -50,6 +50,11 @@ const convertUrlToMobile = url => {
 
 const strip = html => {
 	const doc = new window.DOMParser().parseFromString( html, 'text/html' )
+	for ( const span of doc.querySelectorAll( 'span' ) ) {
+		if ( span.style.display === 'none' ) {
+			span.remove()
+		}
+	}
 	return doc.body.textContent || ''
 }
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T289500

Sometimes, the API returns the following HTML for the author of an image: `<div class=\"fn value\">\nUnknown artist<span style=\"display: none;\">Unknown artist</span>\n</div>`

The span is hidden so it's not really a problem but when we strip extract the text content from the HTML we get all text so we end up with "Unknown artistUnknown artist".

Added explicit removal of hidden spans from the strip function.