### PR TITLE
T289471: Add bdi tags for gallery text

### DIFF
--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -98,12 +98,12 @@ const renderImageInfo = ( mediaInfo, image ) => {
 	return `
 		<div class="${prefixClassname}-item-caption">
 			${isCaptionExpandable() ? `<div class="${prefixClassname}-item-caption-expand-cue"></div>` : ''}
-			${description ? `<div class="${prefixClassname}-item-caption-text">${description}</div>` : ''}
+			${description ? `<div class="${prefixClassname}-item-caption-text"><bdi>${description}</bdi></div>` : ''}
 		</div>
 		<div class="${prefixClassname}-item-attribution">
 			<div class="${prefixClassname}-item-attribution-info">
 				${getLicenseInfo( mediaInfo.license )}
-				${author ? `<div class="${prefixClassname}-item-attribution-info-author">${author}</div>` : ''}
+				${author ? `<div class="${prefixClassname}-item-attribution-info-author"><bdi>${author}</bdi></div>` : ''}
 			</div>
 			${link ? `<div class="${prefixClassname}-item-attribution-more-info">
 				<a href="${link}" class="${prefixClassname}-item-attribution-more-info-link" target="_blank"></a>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T289471

Embedding the `<bdi>` within the existing `<div>` (instead of replacing the existing `<div>` with `<bdi>`) because in testing I’m seeing that replacing the `<div>` messes with the the text placement for the author. 

<img width="756" alt="image" src="https://user-images.githubusercontent.com/4752599/134943335-f609db42-3ea8-4674-aecf-dbc054e44a42.png">
