### PR TITLE
T289471: Include ellipsis in context with bdi text

### DIFF
--- a/src/gallery/slider.js
+++ b/src/gallery/slider.js
@@ -103,7 +103,7 @@ const renderImageInfo = ( mediaInfo, image ) => {
 		<div class="${prefixClassname}-item-attribution">
 			<div class="${prefixClassname}-item-attribution-info">
 				${getLicenseInfo( mediaInfo.license )}
-				${author ? `<div class="${prefixClassname}-item-attribution-info-author"><bdi>${author}</bdi></div>` : ''}
+				${author ? `<bdi class="${prefixClassname}-item-attribution-info-author">${author}</bdi>` : ''}
 			</div>
 			${link ? `<div class="${prefixClassname}-item-attribution-more-info">
 				<a href="${link}" class="${prefixClassname}-item-attribution-more-info-link" target="_blank"></a>

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -166,14 +166,18 @@
 					}
 
 					&-author {
-						width: 220px;
 						height: 14px;
 						margin-right: 4px;
 						font-size: 12px;
 						color: #fff;
-						overflow: hidden;
-						text-overflow: ellipsis;
-						white-space: nowrap;
+
+						bdi {
+							display: inline-block;
+							text-overflow: ellipsis;
+							white-space: nowrap;
+							overflow: hidden;
+							max-width: 220px;
+						}
 					}
 				}
 

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -166,18 +166,14 @@
 					}
 
 					&-author {
+						max-width: 220px;
 						height: 14px;
 						margin-right: 4px;
 						font-size: 12px;
 						color: #fff;
-
-						bdi {
-							display: inline-block;
-							text-overflow: ellipsis;
-							white-space: nowrap;
-							overflow: hidden;
-							max-width: 220px;
-						}
+						overflow: hidden;
+						text-overflow: ellipsis;
+						white-space: nowrap;
 					}
 				}
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T289471

Follow up to #149, this include the ellipsis in context with `<bdi>` text

<img width="710" alt="image" src="https://user-images.githubusercontent.com/4752599/135080196-af018c4b-9d87-40c4-bf61-efbd70ba4ab7.png">

