### PR TITLE
Use a distinct wprov param for touch devices

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -66,7 +66,7 @@ const getDeviceSize = () => {
 	return { height: window.innerHeight, width: window.innerWidth }
 }
 
-const getAnalyticsQueryParam = () => 'wprov=wppw1'
+const getAnalyticsQueryParam = () => 'wprov=wppw1' + ( isTouch ? 't' : '' )
 
 const buildWikipediaUrl = ( lang, title, touch, analytics = true ) => {
 	return `https://${lang}${touch ? '.m' : ''}.wikipedia.org/wiki/${encodeURIComponent( title )}${analytics ? `?${getAnalyticsQueryParam()}` : ''}`


### PR DESCRIPTION
https://phabricator.wikimedia.org/T297172

This allows analytics to distinguish API requests coming from touch devices.