### PR TITLE
Use fixed position on desktop

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -3,23 +3,22 @@ import '../style/popup.less'
 let popup
 
 const computePopupPosition = (
-	targetRect, popupWidth, scrollX, scrollY, innerWidth, innerHeight
+	targetRect,
+	popupWidth, popupHeight,
+	innerWidth, innerHeight
 ) => {
-	let left
-	let right = ''
-	let top = ''
-	let bottom = ''
+	const targetCenterX = targetRect.left + targetRect.width / 2
+	const targetCenterY = targetRect.top + targetRect.height / 2
 
-	left = targetRect.left > ( innerWidth / 2 ) ?
-		( scrollX + targetRect.right - popupWidth ) :
-		( scrollX + targetRect.left )
+	const left = targetCenterX > innerWidth / 2 ?
+		targetRect.left + targetRect.width - popupWidth :
+		targetRect.left
 
-	if ( targetRect.top > ( innerHeight / 2 ) ) {
-		bottom = ( innerHeight - targetRect.top - scrollY )
-	} else {
-		top = ( scrollY + targetRect.bottom )
-	}
-	return { left, right, top, bottom }
+	const top = targetCenterY > innerHeight / 2 ?
+		targetRect.top - popupHeight :
+		targetRect.top + targetRect.height
+
+	return { left, top }
 }
 
 const withPx = value => {
@@ -73,33 +72,16 @@ const createPopup = ( container, win = window ) => {
 	const show = ( content, nextTo, pointerPosition ) => {
 		popup.innerHTML = content
 
-		const scrollX = ( win.pageXOffset !== undefined ) ?
-			win.pageXOffset :
-			(
-				win.document.documentElement ||
-				win.document.body.parentNode ||
-				win.document.body
-			).scrollLeft
-		const scrollY = ( win.pageYOffset !== undefined ) ?
-			win.pageYOffset :
-			(
-				win.document.documentElement ||
-				win.document.body.parentNode ||
-				win.document.body
-			).scrollTop
 		const position = computePopupPosition(
 			getTargetRect( nextTo, pointerPosition ),
 			popup.offsetWidth,
-			scrollX,
-			scrollY,
+			popup.offsetHeight,
 			win.innerWidth,
 			win.innerHeight
 		)
 
 		popup.style.left = withPx( position.left )
-		popup.style.right = withPx( position.right )
 		popup.style.top = withPx( position.top )
-		popup.style.bottom = withPx( position.bottom )
 
 		popup.currentTargetElement = nextTo
 		popup.style.visibility = 'visible'

--- a/style/popup.less
+++ b/style/popup.less
@@ -8,7 +8,7 @@
 	box-shadow: 0 30px 90px -20px rgba( 0, 0, 0, 0.3 ), 0 0 1px 1px rgba( 0, 0, 0, 0.05 );
 	z-index: @popup-z-index;
 	overflow: hidden;
-	position: absolute;
+	position: fixed;
 }
 
 .wp-touch-popup {

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -20,18 +20,15 @@ describe( 'computePopupPosition', () => {
 		`,
 	() => {
 		let position
-		const targetRect = { x: 50, y: 20, top: 20, right: 60, bottom: 25, left: 50 }
-		const popupWidth = 70
-		const scroll = { x: 0, y: 0 }
-		const viewport = { width: 150, height: 100 }
+		const targetRect = { top: 50, left: 60, height: 25, width: 50 }
+		const popupSize = { width: 70, height: 40 }
+		const viewport = { width: 500, height: 400 }
 		before( () => {
-			position = computePopupPosition( targetRect, popupWidth,
-				scroll.x, scroll.y, viewport.width, viewport.height )
+			position = computePopupPosition( targetRect, popupSize.width, popupSize.height,
+				viewport.width, viewport.height )
 		} )
-		it( 'is under the target', () => assert.equal( position.top, 25 ) )
-		it( 'is left-aligned', () => assert.equal( position.left, 50 ) )
-		it( 'does not specify right', () => assert.equal( position.right, '' ) )
-		it( 'does not specify bottom', () => assert.equal( position.bottom, '' ) )
+		it( 'is under the target', () => assert.equal( position.top, 75 ) )
+		it( 'is left-aligned', () => assert.equal( position.left, 60 ) )
 	}
 	)
 
@@ -49,18 +46,15 @@ describe( 'computePopupPosition', () => {
 		`,
 	() => {
 		let position
-		const targetRect = { x: 100, y: 20, top: 20, right: 110, bottom: 25, left: 100 }
-		const popupWidth = 70
-		const scroll = { x: 0, y: 0 }
-		const viewport = { width: 150, height: 100 }
+		const targetRect = { top: 50, left: 370, height: 25, width: 50 }
+		const popupSize = { width: 70, height: 40 }
+		const viewport = { width: 500, height: 400 }
 		before( () => {
-			position = computePopupPosition( targetRect, popupWidth,
-				scroll.x, scroll.y, viewport.width, viewport.height )
+			position = computePopupPosition( targetRect, popupSize.width, popupSize.height,
+				viewport.width, viewport.height )
 		} )
-		it( 'is under the target', () => assert.equal( position.top, 25 ) )
-		it( 'is right-aligned', () => assert.equal( position.left, 40 ) )
-		it( 'does not specify right', () => assert.equal( position.right, '' ) )
-		it( 'does not specify bottom', () => assert.equal( position.bottom, '' ) )
+		it( 'is under the target', () => assert.equal( position.top, 75 ) )
+		it( 'is right-aligned', () => assert.equal( position.left, 350 ) )
 	}
 	)
 
@@ -78,18 +72,15 @@ describe( 'computePopupPosition', () => {
 		`,
 	() => {
 		let position
-		const targetRect = { x: 50, y: 80, top: 80, right: 60, bottom: 90, left: 50 }
-		const popupWidth = 70
-		const scroll = { x: 0, y: 0 }
-		const viewport = { width: 150, height: 100 }
+		const targetRect = { top: 310, left: 70, height: 25, width: 50 }
+		const popupSize = { width: 70, height: 40 }
+		const viewport = { width: 500, height: 400 }
 		before( () => {
-			position = computePopupPosition( targetRect, popupWidth,
-				scroll.x, scroll.y, viewport.width, viewport.height )
+			position = computePopupPosition( targetRect, popupSize.width, popupSize.height,
+				viewport.width, viewport.height )
 		} )
-		it( 'is over the target', () => assert.equal( position.bottom, 20 ) )
-		it( 'is left-aligned', () => assert.equal( position.left, 50 ) )
-		it( 'does not specify right', () => assert.equal( position.right, '' ) )
-		it( 'does not specify top', () => assert.equal( position.top, '' ) )
+		it( 'is over the target', () => assert.equal( position.top, 270 ) )
+		it( 'is left-aligned', () => assert.equal( position.left, 70 ) )
 	}
 	)
 
@@ -107,18 +98,15 @@ describe( 'computePopupPosition', () => {
 		`,
 	() => {
 		let position
-		const targetRect = { x: 100, y: 80, top: 80, right: 110, bottom: 85, left: 100 }
-		const popupWidth = 70
-		const scroll = { x: 0, y: 0 }
-		const viewport = { width: 150, height: 100 }
+		const targetRect = { top: 310, left: 410, height: 25, width: 50 }
+		const popupSize = { width: 70, height: 40 }
+		const viewport = { width: 500, height: 400 }
 		before( () => {
-			position = computePopupPosition( targetRect, popupWidth,
-				scroll.x, scroll.y, viewport.width, viewport.height )
+			position = computePopupPosition( targetRect, popupSize.width, popupSize.height,
+				viewport.width, viewport.height )
 		} )
-		it( 'is over the target', () => assert.equal( position.bottom, 20 ) )
-		it( 'is right-aligned', () => assert.equal( position.left, 40 ) )
-		it( 'does not specify right', () => assert.equal( position.right, '' ) )
-		it( 'does not specify top', () => assert.equal( position.top, '' ) )
+		it( 'is over the target', () => assert.equal( position.top, 270 ) )
+		it( 'is right-aligned', () => assert.equal( position.left, 390 ) )
 	}
 	)
 
@@ -136,18 +124,41 @@ describe( 'computePopupPosition', () => {
 		`,
 	() => {
 		let position
-		const targetRect = { x: 50, y: 20, top: 20, right: 60, bottom: 25, left: 50 }
-		const popupWidth = 70
-		const scroll = { x: 0, y: 10 }
-		const viewport = { width: 150, height: 100 }
+		const targetRect = { top: 50, left: 60, height: 25, width: 50 }
+		const popupSize = { width: 70, height: 40 }
+		const viewport = { width: 500, height: 400 }
 		before( () => {
-			position = computePopupPosition( targetRect, popupWidth,
-				scroll.x, scroll.y, viewport.width, viewport.height )
+			position = computePopupPosition( targetRect, popupSize.width, popupSize.height,
+				viewport.width, viewport.height )
 		} )
-		it( 'is under the target and includes a scroll offset', () => assert.equal( position.top, 35 ) )
-		it( 'is left-aligned', () => assert.equal( position.left, 50 ) )
-		it( 'does not specify right', () => assert.equal( position.right, '' ) )
-		it( 'does not specify bottom', () => assert.equal( position.bottom, '' ) )
+		it( 'is under the target', () => assert.equal( position.top, 75 ) )
+		it( 'is left-aligned', () => assert.equal( position.left, 60 ) )
+	}
+	)
+
+	describe( `
+ __________________________
+|       _________          |
+|      |         |         |
+|      |         |         |
+|      |_________|         |
+|       _v_               ||
+|      |___|              ||
+|                         || <- scrollbar
+|                          |
+|__________________________|
+		`,
+	() => {
+		let position
+		const targetRect = { top: 310, left: 70, height: 25, width: 50 }
+		const popupSize = { width: 70, height: 40 }
+		const viewport = { width: 500, height: 400 }
+		before( () => {
+			position = computePopupPosition( targetRect, popupSize.width, popupSize.height,
+				viewport.width, viewport.height )
+		} )
+		it( 'is over the target', () => assert.equal( position.top, 270 ) )
+		it( 'is left-aligned', () => assert.equal( position.left, 70 ) )
 	}
 	)
 
@@ -167,18 +178,15 @@ describe( 'computePopupPosition', () => {
 		`,
 	() => {
 		let position
-		const targetRect = { x: 100, y: 80, top: 80, right: 110, bottom: 85, left: 100 }
-		const popupWidth = 70
-		const scroll = { x: 10, y: 0 }
-		const viewport = { width: 150, height: 100 }
+		const targetRect = { top: 310, left: 410, height: 25, width: 50 }
+		const popupSize = { width: 70, height: 40 }
+		const viewport = { width: 500, height: 400 }
 		before( () => {
-			position = computePopupPosition( targetRect, popupWidth,
-				scroll.x, scroll.y, viewport.width, viewport.height )
+			position = computePopupPosition( targetRect, popupSize.width, popupSize.height,
+				viewport.width, viewport.height )
 		} )
-		it( 'is over the target', () => assert.equal( position.bottom, 20 ) )
-		it( 'is right-aligned and includes a scroll offset', () => assert.equal( position.left, 50 ) )
-		it( 'does not specify right', () => assert.equal( position.right, '' ) )
-		it( 'does not specify top', () => assert.equal( position.top, '' ) )
+		it( 'is over the target', () => assert.equal( position.top, 270 ) )
+		it( 'is right-aligned', () => assert.equal( position.left, 390 ) )
 	}
 	)
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T306663

On this [site](https://gorhambury.org/), the body has `position: relative` and that's throwing the positioning logic off. 

On this other [site](https://diff.wikimedia.org/2022/06/06/in-search-of-the-least-viewed-article-on-wikipedia/), positioning is strangely but the popup's `bottom` property is often set to a large negative value and I have no idea why it works.

This PR tries to simplify positioning by using only `top`, `left`, `width` and `height` of the popup and the target and using fixed position so it is not relative to any specific element.

Scroll position doesn't appear to be needed so it was removed.

I tested by adding a very large padding to the body of the demo articles so I can scroll around and make sure the popup is positioned correctly next to the target.

Unit tests also updated.