### PR TITLE
T329512: Add wordpress class selector

### DIFF
--- a/style/link.css
+++ b/style/link.css
@@ -1,3 +1,7 @@
+/* Needed to allow .wmf-wp-* classes to be available for Wordpress plugin.
+See https://github.com/wikimedia/wikipedia-preview#wordpress-plugin for more info */
+.wp-block {}
+
 .wmf-wp-with-preview {
   background-color: #eaf3ff;
   padding: 2px 2px 2px 2px;


### PR DESCRIPTION
[T329512](https://phabricator.wikimedia.org/T329512)

Adds `.wp-block` selector so that link styling gets correctly picked up by Wordpress plugin. Context: https://github.com/WordPress/gutenberg/issues/41821. I tested by adding it locally directly to the link CSS file in the plugin. 