### PR TITLE
specific node engines version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: '17'
 
       - name: Install and Build
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: 'latest'
 
       - name: Install and Build
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '17'
+          node-version: '16.20.2'
 
       - name: Install and Build
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 'latest'
+          node-version: '18'
 
       - name: Install and Build
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16.20.2'
+          node-version: '16'
 
       - name: Install and Build
         run: |

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.8.0",
   "description": "Shows Wikipedia article preview in a popup",
   "main": "dist/wikipedia-preview.production.js",
+  "engines": {
+    "node": "<=16.20.2"
+  },
   "scripts": {
     "test": "mocha --require ignore-styles,@babel/register,jsdom-global/register",
     "test:watch": "mocha --require ignore-styles,@babel/register,jsdom-global/register -w",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Shows Wikipedia article preview in a popup",
   "main": "dist/wikipedia-preview.production.js",
   "engines": {
-    "node": "<=16.20.2"
+    "node": "<17"
   },
   "scripts": {
     "test": "mocha --require ignore-styles,@babel/register,jsdom-global/register",


### PR DESCRIPTION
the package will fail to build if starting from Node.js version 17. the supported version is added in CI config and specified engines in package.json file.