### PR TITLE
T345056: Add color var to ul style

### DIFF
--- a/style/preview.less
+++ b/style/preview.less
@@ -96,6 +96,7 @@
 			padding-left: 35px;
 			padding-right: 20px;
 			line-height: 1.6;
+			color: var( --wikipediapreview-primary-color );
 		}
 
 		&-message {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T345056

Followup— forgot the `ul`s 

<img width="966" alt="image" src="https://github.com/wikimedia/wikipedia-preview/assets/4752599/c1b1c087-882a-4d50-8634-aa7b9a48fd1f">


