### PR TITLE
Introduce controller to handle most logic

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -1,0 +1,177 @@
+import { requestPagePreview } from './api'
+import { customEvents } from './event'
+import { createPopup } from './popup'
+import { createTouchPopup } from './touchPopup'
+import { renderPreview, renderLoading, renderError, renderDisambiguation, renderOffline } from './preview'
+import { isTouch, getDir, isOnline, invokeCallback } from './utils'
+
+const Status = {
+	UNKNOWN: 'unknown',
+	READY: 'ready',
+	LOADING: 'loading',
+	SHOWN_OK: 'shown_ok',
+	SHOWN_ERROR: 'shown_error'
+}
+
+const state = {
+	colorScheme: null,
+	events: {},
+	lang: null,
+	title: null,
+	target: null,
+	pointer: { x: 0, y: 0 },
+	status: Status.UNKNOWN,
+	requestId: null
+}
+
+let popup
+
+const controller = {
+	init: ( popupContainer, prefersColorScheme, events ) => {
+		popup = isTouch ?
+			createTouchPopup( popupContainer ) :
+			createPopup( popupContainer )
+		popup.subscribe( customEvents( popup ) )
+		state.colorScheme = prefersColorScheme
+		state.events = events
+		state.status = Status.READY
+	},
+	trigger: ( title, lang, pointer, target ) => {
+		// GUARD CLAUSES
+
+		// Not initiliazed yet
+		if ( state.status === Status.UNKNOWN ) {
+			return
+		}
+
+		// New trigger on the same target, and not a refresh
+		if (
+			state.target === target &&
+			state.status !== Status.SHOWN_ERROR
+		) {
+			return
+		}
+
+		// All good, moving on
+
+		// Hide the old popup
+		if ( popup.element.style.visibility === 'visible' ) {
+			popup.hide()
+		}
+
+		// Generate a new unique request ID to ensure
+		// callbacks from older requests are ignored
+		const requestId = state.requestId = Date.now()
+
+		state.title = title
+		state.lang = lang
+		state.target = target
+		state.status = Status.LOADING
+
+		popup.dir = getDir( lang )
+		popup.show(
+			renderLoading(
+				isTouch,
+				lang,
+				popup.dir,
+				status.colorScheme
+			),
+			target,
+			pointer
+		)
+
+		requestPagePreview( lang, title, ( data ) => {
+			// Compare request id in state and closure
+			// to ensure this callback is not outdated
+			if ( requestId !== state.requestId ) {
+				return
+			}
+			if ( state.status === Status.LOADING ) {
+				popup.loading = false
+				if ( data ) {
+					popup.lang = lang
+					popup.title = title
+					if ( data.type === 'standard' ) {
+						popup.show(
+							renderPreview(
+								lang,
+								data,
+								isTouch,
+								state.colorScheme
+							),
+							target,
+							pointer
+						)
+						invokeCallback( state.events, 'onShow', [ title, lang, 'standard' ] )
+					} else if ( data.type === 'disambiguation' ) {
+						const content = data.extractHtml ?
+							renderPreview(
+								lang,
+								data,
+								isTouch,
+								state.colorScheme
+							) :
+							// fallback message when no extract is found on disambiguation page
+							renderDisambiguation(
+								isTouch,
+								lang,
+								data.title,
+								data.dir,
+								state.colorScheme
+							)
+						popup.show(
+							content,
+							target,
+							pointer
+						)
+						invokeCallback( state.events, 'onShow', [ title, lang, 'disambiguation' ] )
+					}
+				} else {
+					if ( isOnline() ) {
+						popup.show(
+							renderError(
+								isTouch,
+								lang,
+								title,
+								popup.dir,
+								state.colorScheme
+							),
+							target,
+							pointer
+						)
+						invokeCallback( state.events, 'onShow', [ title, lang, 'error' ] )
+					} else {
+						popup.show(
+							renderOffline(
+								isTouch,
+								lang,
+								popup.dir,
+								state.colorScheme
+							),
+							target,
+							pointer
+						)
+						invokeCallback( state.events, 'onShow', [ title, lang, 'offline' ] )
+						const refreshBtn = popup.element.querySelector( '.wikipediapreview-body-action' )
+						refreshBtn.addEventListener( 'click', () => {
+							controller.trigger( title, lang, pointer, target )
+						} )
+					}
+				}
+				const readOnWikiCta = popup.element.querySelector( '.wikipediapreview-footer-cta-readonwiki, .wikipediapreview-cta-readonwiki' )
+				if ( readOnWikiCta ) {
+					readOnWikiCta.addEventListener( 'click', () => {
+						invokeCallback( state.events, 'onWikiRead', [ title, lang ] )
+					} )
+				}
+			}
+		} )
+	},
+	close: () => {
+		if ( popup ) {
+			popup.hide()
+		}
+	}
+}
+
+export default controller

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,7 +30,11 @@ const getWikipediaAttrFromUrl = ( url ) => {
 	for ( let i = 0; i < regexList.length; i++ ) {
 		const matches = regexList[ i ].exec( url )
 		if ( matches ) {
-			return { lang: matches[ 1 ], mobile: !!matches[ 2 ], title: decodeUri( matches[ 3 ] ) }
+			return {
+				lang: matches[ 1 ],
+				mobile: !!matches[ 2 ],
+				title: decodeUri( matches[ 3 ] )
+			}
 		}
 	}
 
@@ -98,8 +102,57 @@ const logError = ( ...err ) => {
 	console.error.apply( console, err ) // eslint-disable-line no-console
 }
 
+const forEachRoot = ( rootConfig, selector, callback ) => {
+	const roots = []
+	// rootConfig can be a selector (String)
+	if (
+		typeof rootConfig === 'string' ||
+		rootConfig instanceof String
+	) {
+		Array.prototype.forEach.call(
+			document.querySelectorAll( rootConfig ),
+			( node ) => {
+				roots.push( node )
+			}
+		)
+	}
+
+	// rootConfig can be a node (Document or Element)
+	if ( rootConfig instanceof Document || rootConfig instanceof Element ) {
+		roots.push( rootConfig )
+	}
+
+	// rootConfig can be a list of nodes (Element[])
+	if ( Array.isArray( rootConfig ) ) {
+		rootConfig.forEach( ( r ) => {
+			if ( r instanceof Element ) {
+				roots.push( r )
+			}
+		} )
+	}
+
+	roots.forEach( ( root ) => {
+		Array.prototype.forEach.call(
+			root.querySelectorAll( selector ),
+			callback
+		)
+	} )
+}
+
+const invokeCallback = ( events, name, params ) => {
+	const callback = events && events[ name ]
+	if ( callback instanceof Function ) {
+		try {
+			callback.apply( null, params )
+		} catch ( e ) {
+			// eslint-disable-next-line no-console
+			console.log( 'Error invoking Wikipedia Preview custom callback', e )
+		}
+	}
+}
+
 export {
 	getWikipediaAttrFromUrl, isTouch, isOnline, getDir, buildMwApiUrl,
 	convertUrlToMobile, strip, sanitizeHTML, getDeviceSize, getAnalyticsQueryParam,
-	buildWikipediaUrl, version, logError
+	buildWikipediaUrl, version, logError, forEachRoot, invokeCallback
 }


### PR DESCRIPTION
Refactor

- Break up big index.js file
- Introduce controller.js with explicit state and status
- Move various functions to utils
- Simplify previews and links registration

Open issues

- There is logic in events.js that relies on state put on the popup (loading, title, lang, etc), which I was trying to get rid of. How can we refactor events.js to put decisions based on state in controller.js?