### PR TITLE
T360002 remove font weight setting for link

### DIFF
--- a/demo/css/link.css
+++ b/demo/css/link.css
@@ -1,6 +1,5 @@
 .wmf-wp-with-preview {
   position: relative;
-  color: inherit;
   cursor: pointer;
 }
 

--- a/demo/css/link.css
+++ b/demo/css/link.css
@@ -1,6 +1,5 @@
 .wmf-wp-with-preview {
   position: relative;
-  font-weight: 400;
   color: inherit;
   cursor: pointer;
 }


### PR DESCRIPTION
Phabricator: https://phabricator.wikimedia.org/T360002

this is not being used, anyone can overwrite the styling of the link (including wordpress style)