### PR TITLE
Place dark theme class names higher up the DOM

### DIFF
--- a/src/components/preview.js
+++ b/src/components/preview.js
@@ -33,12 +33,10 @@ const getReadOnWikiCta = ( lang, title, isTouch ) => {
 	return `<a href="${ buildWikipediaUrl( lang, title, isTouch ) }" target="_blank" class="wikipediapreview-cta-readonwiki">${ msg( lang, 'read-on-wiki' ) }</a>`
 }
 
-const render = ( lang, isTouch, dir, headerContent, bodyContent, prefersColorScheme ) => {
+const render = ( lang, isTouch, dir, headerContent, bodyContent ) => {
 	const classes = {
 		wikipediapreview: true,
-		mobile: isTouch,
-		'wikipediapreview-dark-theme': prefersColorScheme === 'dark',
-		'wikipediapreview-light-theme': prefersColorScheme === 'light'
+		mobile: isTouch
 	}
 	return `
 		<div class="${ classesToString( classes ) }" lang="${ lang }" dir="${ dir }" onmouseleave="close">
@@ -48,7 +46,7 @@ const render = ( lang, isTouch, dir, headerContent, bodyContent, prefersColorSch
 	`.trim()
 }
 
-const renderPreview = ( lang, data, media, expanded, isTouch, prefersColorScheme ) => {
+const renderPreview = ( lang, data, media, expanded, isTouch ) => {
 	const imageUrl = data.imgUrl,
 		gallery = galleryrow( media, lang ),
 		footerContent = expanded ?
@@ -69,12 +67,11 @@ const renderPreview = ( lang, data, media, expanded, isTouch, prefersColorScheme
 		isTouch,
 		data.dir,
 		header( lang, imageUrl ),
-		bodyContent,
-		prefersColorScheme
+		bodyContent
 	)
 }
 
-const renderLoading = ( isTouch, lang, dir, prefersColorScheme ) => {
+const renderLoading = ( isTouch, lang, dir ) => {
 	const bodyContent = `
 		<div class="wikipediapreview-body wikipediapreview-body-loading">
 			<div class="wikipediapreview-body-loading-line larger"></div>
@@ -91,28 +88,28 @@ const renderLoading = ( isTouch, lang, dir, prefersColorScheme ) => {
 		<div class="wikipediapreview-footer-loading"></div>
 	`.trim()
 
-	return render( lang, isTouch, dir, header( lang ), bodyContent, prefersColorScheme )
+	return render( lang, isTouch, dir, header( lang ), bodyContent )
 }
 
-const renderError = ( isTouch, lang, title, dir, prefersColorScheme ) => {
+const renderError = ( isTouch, lang, title, dir ) => {
 	const message = `<span>${ msg( lang, 'preview-error-message' ) }</span>`
 	const cta = getReadOnWikiCta( lang, title, isTouch )
 
-	return render( lang, isTouch, dir, header( lang ), getPreviewBody( 'error', message, cta ), prefersColorScheme )
+	return render( lang, isTouch, dir, header( lang ), getPreviewBody( 'error', message, cta ) )
 }
 
-const renderDisambiguation = ( isTouch, lang, title, dir, prefersColorScheme ) => {
+const renderDisambiguation = ( isTouch, lang, title, dir ) => {
 	const message = `<span>${ msg( lang, 'preview-disambiguation-message', title ) }</span>`
 	const cta = getReadOnWikiCta( lang, title, isTouch )
 
-	return render( lang, isTouch, dir, header( lang ), getPreviewBody( 'disambiguation', message, cta ), prefersColorScheme )
+	return render( lang, isTouch, dir, header( lang ), getPreviewBody( 'disambiguation', message, cta ) )
 }
 
-const renderOffline = ( isTouch, lang, dir, prefersColorScheme ) => {
+const renderOffline = ( isTouch, lang, dir ) => {
 	const message = `<span>${ msg( lang, 'preview-offline-message' ) }</span>`
 	const cta = `<a>${ msg( lang, 'preview-offline-cta' ) }</a>`
 
-	return render( lang, isTouch, dir, header( lang ), getPreviewBody( 'offline', message, cta ), prefersColorScheme )
+	return render( lang, isTouch, dir, header( lang ), getPreviewBody( 'offline', message, cta ) )
 }
 
 const bodyLoading = () => {
@@ -255,9 +252,7 @@ const preview = ( state ) => {
 	const type = getPreviewType( state )
 	const classes = {
 		wikipediapreview: true,
-		mobile: state.isTouch,
-		'wikipediapreview-dark-theme': state.colorScheme === 'dark',
-		'wikipediapreview-light-theme': state.colorScheme === 'light'
+		mobile: state.isTouch
 	}
 	return `
 		<div class="${ classesToString( classes ) } ${ state.expanded ? 'expanded' : '' }" lang="${ state.lang }" dir="${ getDir( state.lang ) }" onmouseleave="close">

--- a/src/index.js
+++ b/src/index.js
@@ -35,12 +35,12 @@ function init( {
 	}
 	store.setColorScheme( prefersColorScheme )
 
-	let container = document.querySelector( '.wp-popup-containerner' )
+	let container = document.querySelector( '.wp-popup-container' )
 	if ( !container ) {
 		container = document.createElement( 'div' )
 		container.classList.add( 'wp-popup-container' )
 		popupContainer.appendChild( container )
-		
+
 		if ( prefersColorScheme === 'dark' ) {
 			container.classList.add( 'wikipediapreview-dark-theme' )
 		} else if ( prefersColorScheme === 'light' ) {

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,19 @@ const getPreviewHtml = ( title, lang, callback ) => {
 	} )
 }
 
+const setColorScheme = ( container, prefersColorScheme ) => {
+	if ( prefersColorScheme === 'dark' ) {
+		container.classList.add( 'wikipediapreview-dark-theme' )
+		container.classList.remove( 'wikipediapreview-light-theme' )
+	} else if ( prefersColorScheme === 'light' ) {
+		container.classList.add( 'wikipediapreview-light-theme' )
+		container.classList.remove( 'wikipediapreview-dark-theme' )
+	} else {
+		container.classList.remove( 'wikipediapreview-light-theme' )
+		container.classList.remove( 'wikipediapreview-dark-theme' )
+	}
+}
+
 function init( {
 	root = document,
 	selector = '[data-wikipedia-preview]',
@@ -33,20 +46,15 @@ function init( {
 	if ( events === 1 ) {
 		return
 	}
-	store.setColorScheme( prefersColorScheme )
 
 	let container = document.querySelector( '.wp-popup-container' )
 	if ( !container ) {
 		container = document.createElement( 'div' )
 		container.classList.add( 'wp-popup-container' )
 		popupContainer.appendChild( container )
-
-		if ( prefersColorScheme === 'dark' ) {
-			container.classList.add( 'wikipediapreview-dark-theme' )
-		} else if ( prefersColorScheme === 'light' ) {
-			container.classList.add( 'wikipediapreview-light-theme' )
-		}
 	}
+
+	setColorScheme( container, prefersColorScheme )
 
 	component(
 		container,

--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,12 @@ function init( {
 		container = document.createElement( 'div' )
 		container.classList.add( 'wp-popup-container' )
 		popupContainer.appendChild( container )
-		// todo: consider putting the 'dark' class
-		// at this level
+		
+		if ( prefersColorScheme === 'dark' ) {
+			container.classList.add( 'wikipediapreview-dark-theme' )
+		} else if ( prefersColorScheme === 'light' ) {
+			container.classList.add( 'wikipediapreview-light-theme' )
+		}
 	}
 
 	component(

--- a/src/store.js
+++ b/src/store.js
@@ -10,13 +10,8 @@ const wpStore = store( {
 	data: null,
 	media: null,
 	mediaInfo: {},
-	expanded: false,
-	colorScheme: 'detect'
+	expanded: false
 }, {
-	setColorScheme( state, colorScheme ) {
-		state.colorScheme = colorScheme
-	},
-
 	trigger( state, targetId, pointerPosition, title, lang ) {
 		// reset
 		state.data = null

--- a/src/stories/preview.stories.js
+++ b/src/stories/preview.stories.js
@@ -27,11 +27,6 @@ export default {
 		imgUrl: {
 			name: 'Thumbnail URL',
 			control: 'text'
-		},
-		colorScheme: {
-			name: 'Color Scheme',
-			control: 'inline-radio',
-			options: [ 'light', 'dark', 'detect' ]
 		}
 	},
 	args: {
@@ -40,32 +35,29 @@ export default {
 		title: 'Cat',
 		pageUrl: 'https://en.wikipedia.org/wiki/Cat',
 		extractHtml: '<p><strong>Lorem ipsum dolor sit amet,</strong> consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. <br/><br/>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>',
-		imgUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Moons_of_solar_system-he.svg/langhe-320px-Moons_of_solar_system-he.svg.png',
-		colorScheme: 'light'
+		imgUrl: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Moons_of_solar_system-he.svg/langhe-320px-Moons_of_solar_system-he.svg.png'
 	}
 }
 
 export const StandardWithImage = ( {
-	lang, title, extractHtml, pageUrl, imgUrl, touch, colorScheme
+	lang, title, extractHtml, pageUrl, imgUrl, touch
 } ) => {
 	return preview( {
 		lang,
 		data: { type: 'standard', title, extractHtml, pageUrl, imgUrl },
-		isTouch: touch,
-		colorScheme
+		isTouch: touch
 	} )
 }
 
-export const Standard = ( { lang, title, extractHtml, pageUrl, touch, colorScheme } ) => {
+export const Standard = ( { lang, title, extractHtml, pageUrl, touch } ) => {
 	return preview( {
 		lang,
 		data: { type: 'standard', title, extractHtml, pageUrl },
-		isTouch: touch,
-		colorScheme
+		isTouch: touch
 	} )
 }
 
-export const Expanded = ( { lang, title, extractHtml, pageUrl, imgUrl, touch, colorScheme } ) => {
+export const Expanded = ( { lang, title, extractHtml, pageUrl, imgUrl, touch } ) => {
 	const media = [
 		{
 			thumb: 'https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Wikipedia-logo-v2.svg/225px-Wikipedia-logo-v2.svg.png'
@@ -78,46 +70,41 @@ export const Expanded = ( { lang, title, extractHtml, pageUrl, imgUrl, touch, co
 		data: { type: 'standard', title, extractHtml, pageUrl, imgUrl },
 		expanded: true,
 		media,
-		isTouch: touch,
-		colorScheme
+		isTouch: touch
 	} )
 	return template
 }
 
-export const Loading = ( { touch, lang, colorScheme } ) => {
+export const Loading = ( { touch, lang } ) => {
 	return preview( {
 		lang,
 		data: { type: 'loading' },
-		isTouch: touch,
-		colorScheme
+		isTouch: touch
 	} )
 }
 
-export const Error = ( { touch, lang, colorScheme } ) => {
+export const Error = ( { touch, lang } ) => {
 	return preview( {
 		lang,
 		data: { type: 'error' },
-		isTouch: touch,
-		colorScheme
+		isTouch: touch
 	} )
 }
 
 export const Disambiguation = Standard
 
-export const DisambiguationWithNoExtract = ( { touch, lang, title, colorScheme } ) => {
+export const DisambiguationWithNoExtract = ( { touch, lang, title } ) => {
 	return preview( {
 		lang,
 		data: { type: 'disambiguation', title },
-		isTouch: touch,
-		colorScheme: colorScheme
+		isTouch: touch
 	} )
 }
 
-export const Offline = ( { touch, lang, colorScheme } ) => {
+export const Offline = ( { touch, lang } ) => {
 	return preview( {
 		lang,
 		data: { type: 'offline' },
-		isTouch: touch,
-		colorScheme
+		isTouch: touch
 	} )
 }

--- a/src/stories/target.stories.js
+++ b/src/stories/target.stories.js
@@ -12,34 +12,40 @@ export default {
 		title: {
 			name: 'Article Title',
 			control: 'text'
+		},
+		colorScheme: {
+			name: 'Color Scheme',
+			control: 'inline-radio',
+			options: [ 'light', 'dark', 'detect' ]
 		}
 	},
 	args: {
 		lang: 'en',
-		title: 'Cat'
+		title: 'Cat',
+		colorScheme: 'light'
 	}
 }
 
-export const Hyperlink = ( { lang, title } ) => {
+export const Hyperlink = ( { lang, title, colorScheme } ) => {
 	const container = document.createElement( 'div' )
 	const template = `<a href="${ buildWikipediaUrl( lang, title, true, false ) }">${ title } (${ lang })</a>`
 	container.innerHTML = template
-	wikipediaPreview.init( { root: container, detectLinks: true } )
+	wikipediaPreview.init( { root: container, detectLinks: true, prefersColorScheme: colorScheme } )
 	return container
 }
 
-export const Image = ( { lang, title } ) => {
+export const Image = ( { lang, title, colorScheme } ) => {
 	const container = document.createElement( 'div' )
 	const template = `<a href="${ buildWikipediaUrl( lang, title, true, false ) }"><img src="https://upload.wikimedia.org/wikipedia/commons/3/3d/Wikipedia-logo-v2.png"></a>`
 	container.innerHTML = template
-	wikipediaPreview.init( { root: container, detectLinks: true } )
+	wikipediaPreview.init( { root: container, detectLinks: true, prefersColorScheme: colorScheme } )
 	return container
 }
 
-export const Text = ( { lang, title } ) => {
+export const Text = ( { lang, title, colorScheme } ) => {
 	const container = document.createElement( 'div' )
 	const template = `<span class="wmf-wp-with-preview" data-wikipedia-preview data-wp-title="${ title }">${ title } (${ lang })</span>`
 	container.innerHTML = template
-	wikipediaPreview.init( { root: container, lang } )
+	wikipediaPreview.init( { root: container, lang, prefersColorScheme: colorScheme } )
 	return container
 }

--- a/style/popup.less
+++ b/style/popup.less
@@ -37,3 +37,40 @@
 	top: 0;
 	bottom: 0;
 }
+
+@media (prefers-color-scheme: dark) {
+	.wp-popup-container {
+		.mixin-wikipediapreview-dark-theme();
+	}
+}
+
+@media (prefers-color-scheme: light) {
+	.wp-popup-container {
+		.mixin-wikipediapreview-light-theme();
+	}
+}
+
+.wp-popup-container.wikipediapreview-dark-theme {
+	.mixin-wikipediapreview-dark-theme();
+	
+}
+
+.wp-popup-container.wikipediapreview-light-theme {
+	.mixin-wikipediapreview-light-theme();
+}
+
+
+.mixin-wikipediapreview-dark-theme () {
+	--wikipediapreview-primary-background-color: #202122;
+	--wikipediapreview-secondary-background-color: #202122;
+	--wikipediapreview-primary-color: #eaecf0;
+	--wikipediapreview-filter-setting: invert(1);
+}
+
+.mixin-wikipediapreview-light-theme () {
+	--wikipediapreview-primary-background-color: #fff;
+	--wikipediapreview-secondary-background-color: #eaecf0;
+	--wikipediapreview-primary-color: #202122;
+	--wikipediapreview-filter-setting: unset;
+}
+

--- a/style/preview.less
+++ b/style/preview.less
@@ -330,39 +330,3 @@
 	flex-direction: column;
 	justify-content: center;
 }
-
-@media (prefers-color-scheme: dark) {
-	.wikipediapreview {
-		.mixin-wikipediapreview-dark-theme();
-	}
-}
-
-@media (prefers-color-scheme: light) {
-	.wikipediapreview {
-		.mixin-wikipediapreview-light-theme();
-	}
-}
-
-.wikipediapreview.wikipediapreview-dark-theme {
-	.mixin-wikipediapreview-dark-theme();
-	
-}
-
-.wikipediapreview.wikipediapreview-light-theme {
-	.mixin-wikipediapreview-light-theme();
-}
-
-
-.mixin-wikipediapreview-dark-theme () {
-	--wikipediapreview-primary-background-color: #202122;
-	--wikipediapreview-secondary-background-color: #202122;
-	--wikipediapreview-primary-color: #eaecf0;
-	--wikipediapreview-filter-setting: invert(1);
-}
-
-.mixin-wikipediapreview-light-theme () {
-	--wikipediapreview-primary-background-color: #fff;
-	--wikipediapreview-secondary-background-color: #eaecf0;
-	--wikipediapreview-primary-color: #202122;
-	--wikipediapreview-filter-setting: unset;
-}


### PR DESCRIPTION
As part of the Wikipedia Preview refactor (https://phabricator.wikimedia.org/T363468), this refactors the dark theme class names placement from `.wikipediapreview` to top level `.wp-popup-container`