### PR TITLE
T363481: Use text-decoration for link style

### DIFF
--- a/demo/css/link.css
+++ b/demo/css/link.css
@@ -1,14 +1,11 @@
 .wmf-wp-with-preview {
   position: relative;
   cursor: pointer;
-}
-
-.wmf-wp-with-preview::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  bottom: -4px;
-  width: 100%;
-  opacity: 0.5;
-  border-bottom: 2px dashed;
+  text-decoration: dashed underline 2px;
+  text-decoration-color: rgba(0, 0, 0, 0.5);
+  text-underline-offset: 4px;
+  /* -webkit for Safari support */
+  -webkit-text-decoration-line: underline;
+  -webkit-text-decoration-style: dashed;
+  -webkit-text-decoration-color: rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
Phab ticket: https://phabricator.wikimedia.org/T363481
Demo: https://wikimedia.github.io/wikipedia-preview/T363481-underline/articles/english.html

Wikipedia Preview links styling is currently implemented using a pseudo element (`::after`). The following issues have been found to be likely due to this implementation:

* When the target is on more than one line, the underline disappears
* The gap between the word(s) and the underline is not part of the element so moving the mouse there will cause the popup to disappear

This PR uses `text-decoration` instead to fix issues above, sample below:

<img width="351" alt="image" src="https://github.com/wikimedia/wikipedia-preview/assets/4752599/7cf2f65c-25c6-413d-83d9-502ae4161f14">
