### PR TITLE
T363481: Remove text decoration color

### DIFF
--- a/demo/css/link.css
+++ b/demo/css/link.css
@@ -2,10 +2,8 @@
   position: relative;
   cursor: pointer;
   text-decoration: dashed underline 2px;
-  text-decoration-color: rgba(0, 0, 0, 0.5);
   text-underline-offset: 4px;
   /* -webkit for Safari support */
   -webkit-text-decoration-line: underline;
   -webkit-text-decoration-style: dashed;
-  -webkit-text-decoration-color: rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T363481

Follow up to  #199, removing text decoration color to cover dark mode support