### PR TITLE
Make arrow a little bigger to avoid gap due to pixel rounding error

### DIFF
--- a/style/popup.less
+++ b/style/popup.less
@@ -9,8 +9,8 @@
 	position: absolute;
 
 	&-arrow {
-		width: 1rem;
-		height: 1rem;
+		width: 17px;
+		height: 17px;
 		position: absolute;
 		clip-path: polygon(50% 0%, 50% 0%, 100% 50%, 0% 50%);
 		// background-color set in preview.less


### PR DESCRIPTION
https://phabricator.wikimedia.org/T360750#9856982

The arrow was 1rem (16px), the offset -8px and some clippath, which means that at some level it's height was <8px so a small gap appeared between it and the popup.

By setting it to 17px, we ensure rounding won't make it smaller than 8px.

Also, rem unit should be avoided for elements that are not expected to change with base text-size.