### PR TITLE
Dynamically import only the needed i18n files

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,7 +11,7 @@ module.exports = {
     module: true
   },
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module'
   },
   ignorePatterns: ["storybook-static", "dist", "vite.config.js"],

--- a/src/api.js
+++ b/src/api.js
@@ -4,7 +4,7 @@ import {
 	strip, getDeviceSize, sanitizeHTML, getAnalyticsQueryParam,
 	getDir
 } from './utils'
-import { msg } from './i18n'
+import { msg, loadMessagesForLang } from './i18n'
 
 const titleWithoutSection = ( title ) => {
 	return title.split( '#' )[ 0 ]
@@ -41,7 +41,10 @@ const requestPcsSummary = ( lang, title, callback, request = cachedRequest ) => 
 	const url = `https://${ lang }.wikipedia.org/api/rest_v1/page/summary/${ encodeURIComponent( title ) }?${ getAnalyticsQueryParam() }`
 	request( url, ( data, err ) => {
 		if ( !data ) {
-			logError( msg( lang, 'preview-console-error-message', title, lang ), err )
+			loadMessagesForLang( lang ).then( () => {
+				logError( msg( lang, 'preview-console-error-message', title, lang ), err )
+			} )
+
 			return false
 		}
 		if ( data.type === 'standard' || data.type === 'disambiguation' ) {
@@ -63,7 +66,10 @@ const requestPcsSummary = ( lang, title, callback, request = cachedRequest ) => 
 				type: 'standard'
 			}
 		}
-		logError( msg( lang, 'preview-console-error-message', title, lang ), data )
+		loadMessagesForLang( lang ).then( () => {
+			logError( msg( lang, 'preview-console-error-message', title, lang ), data )
+		} )
+
 		return false
 	}, callback )
 
@@ -136,7 +142,10 @@ const getSections = ( lang, title, callback, request = cachedRequest ) => {
 	const url = `https://${ lang }.wikipedia.org/api/rest_v1/page/mobile-html/${ encodeURIComponent( title ) }?${ getAnalyticsQueryParam() }`
 	request( url, ( data, err ) => {
 		if ( !data ) {
-			logError( msg( lang, 'preview-console-error-message', title, lang ), err )
+			loadMessagesForLang( lang ).then( () => {
+				logError( msg( lang, 'preview-console-error-message', title, lang ), err )
+			} )
+
 			return false
 		}
 		const doc = new DOMParser().parseFromString( data, 'text/html' )

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -4,14 +4,22 @@ const messages = {
 	en
 }
 
-const msg = ( lang, key, ...params ) => {
+const loadMessagesForLang = ( lang ) => {
 	if ( !messages[ lang ] ) {
-		try {
-			messages[ lang ] = require( `./../i18n/${ lang }.json` ).default
-		} catch ( error ) {
-			messages[ lang ] = {}
-		}
+		// eslint-disable-next-line es-x/no-dynamic-import
+		return import( `./../i18n/${ lang }.json` )
+			.then( ( module ) => {
+				messages[ lang ] = module.default
+			} )
+			.catch( () => {
+				messages[ lang ] = {}
+			} )
 	}
+
+	return Promise.resolve()
+}
+
+const msg = ( lang, key, ...params ) => {
 	let message = messages[ lang ] && messages[ lang ][ key ] || messages.en[ key ] || key
 	params.forEach( ( param, i ) => {
 		message = message.replace( new RegExp( `\\$${ i + 1 }`, 'g' ), param )
@@ -19,4 +27,4 @@ const msg = ( lang, key, ...params ) => {
 	return message
 }
 
-export { msg }
+export { loadMessagesForLang, msg }


### PR DESCRIPTION
This PR adds the appropriate logic so that the code only imports dynamically the translation messages for the languages that are actually needed, instead of loading the messages for all languages.

Regarding, the built artifacts, the `wikipedia-preview.umd.cjs` will continue to load all translation messages, as this is intended to be used as standalone file that contains the whole library. However, the wikipedia-preview.js ESM module will now only load the translation messages for the required families.

Steps followed for testing:
- npm run build
- Create a directory named "dynamic-import-test"
- Inside this directory create a JS file named "app.js" with the following content:
`
import wikipediaPreview from '../dist/wikipedia-preview.js'

wikipediaPreview.init( {
	root: '.content > p, .footer > p',
	detectLinks: true,
	lang: 'fr',
	debug: true
} )
`
- Inside the same directory create a vite config file named `vite.config.app.js` with the following contents (mostly copied from `vite.config.js` file:
`
import { fileURLToPath, URL } from 'node:url'
import { resolve } from 'path'
import { defineConfig } from 'vite'
import commonjs from 'vite-plugin-commonjs'
import fs from 'fs'
import childProcess from 'child_process'

// https://vitejs.dev/config/
export default defineConfig({
  base: '/',
  resolve: {
    alias: {
      '@': fileURLToPath(new URL('./src', import.meta.url))
    }
  },
  plugins: [
    commonjs()
  ],
  define: {
    APP_VERSION: JSON.stringify(JSON.parse(fs.readFileSync('./package.json')).version),
    GIT_HASH: JSON.stringify(childProcess.execSync('git rev-parse --short HEAD').toString().trim())
  },
  build: {
    target: 'es2015',
    lib: {
      entry: resolve(__dirname, './app.js'),
      name: 'app',
      fileName: 'my-app',
    },
    sourcemap: true,
    cssCodeSplit: true,
    rollupOptions: {
      output: {
        assetFileNames: 'my-app.[ext]',
        dir: 'app',
      }
    }
  }
})
`
- Build the new files to use them directly inside HTML: `vite build --config ./dynamic-import-test/vite.config.app.js`
- Then inside `demo/articles/french.html`:
  1. Add the styles inside the <head>:
  `
      <link href="../../dist/wikipedia-preview-link.css" rel="stylesheet" type="text/css"/>
      <link href="../../dist/wikipedia-preview.css" rel="stylesheet" type="text/css"/>
    `
    2. Comment out the previous <script> tags and add this one: `<script src="../../app/my-app.js"></script>`
- Finally, test that the french.html file only loads the required messages.