### PR TITLE
Update the content styling for ol and math elements

### DIFF
--- a/style/preview.less
+++ b/style/preview.less
@@ -101,11 +101,15 @@
 			color: var( --wikipediapreview-primary-color );
 		}
 
-		ul {
+		ol, ul {
 			padding-left: 35px;
 			padding-right: 20px;
 			line-height: 1.6;
 			color: var( --wikipediapreview-primary-color );
+		}
+
+		.mwe-math-element {
+			filter: var( --wikipediapreview-filter-setting );
 		}
 
 		&-message {


### PR DESCRIPTION
fixes https://github.com/wikimedia/wikipedia-preview/issues/232

| 1 | 2 | 3 | 4 |
| --- | --- | --- | --- |
| <img width="333" alt="image" src="https://github.com/user-attachments/assets/77a25dcd-619d-4fb3-bb65-7c651d6ea7df" /> | <img width="398" alt="image" src="https://github.com/user-attachments/assets/f7e8f2fa-dba4-46e9-afbb-20dedf997c5e" /> | <img width="399" alt="image" src="https://github.com/user-attachments/assets/2275f26e-551a-437c-b711-9216d09f175e" /> | <img width="406" alt="image" src="https://github.com/user-attachments/assets/51ae6c9c-ae7a-4369-a748-36e3990e2f3a" /> |
